### PR TITLE
Integrate CleanSpeak for moderation

### DIFF
--- a/datamodel.prisma
+++ b/datamodel.prisma
@@ -1,24 +1,14 @@
-type Post {
-  id: ID! @id
-  createdAt: DateTime! @createdAt
-  updatedAt: DateTime! @updatedAt
-
-  abusive: Boolean! @default(value: false)
-  content: String!
-  published: Boolean! @default(value: false)
-  thread: Thread @relation(link: INLINE)
+enum ModerationStatus {
+  TRIGGERED_CONTENT_FILTER,
+  APPROVED_BY_MODERATOR
 }
 
-type Thread {
+type Moderation {
   id: ID! @id
   createdAt: DateTime! @createdAt
   updatedAt: DateTime! @updatedAt
 
-  abusive: Boolean! @default(value: false)
-  group: Group @relation(link: INLINE)
-  posts: [Post!]!
-  published: Boolean! @default(value: false)
-  title: String!
+  status: ModerationStatus!
 }
 
 type Group {
@@ -29,4 +19,25 @@ type Group {
   description: String!
   name: String!
   threads: [Thread!]!
+}
+
+type Post {
+  id: ID! @id
+  createdAt: DateTime! @createdAt
+  updatedAt: DateTime! @updatedAt
+
+  content: String!
+  moderation: Moderation
+  thread: Thread @relation(link: INLINE)
+}
+
+type Thread {
+  id: ID! @id
+  createdAt: DateTime! @createdAt
+  updatedAt: DateTime! @updatedAt
+
+  group: Group @relation(link: INLINE)
+  moderation: Moderation
+  posts: [Post!]!
+  title: String!
 }

--- a/datamodel.prisma
+++ b/datamodel.prisma
@@ -17,6 +17,7 @@ type Group {
   updatedAt: DateTime! @updatedAt
 
   description: String!
+  moderation: Moderation
   name: String!
   threads: [Thread!]!
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,9 +26,9 @@ services:
   db:
     image: postgres:9.6
     environment:
-      PGDATA: /var/lib/postgresql/data/pgdata
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      - "PGDATA=/var/lib/postgresql/data/pgdata"
+      - "POSTGRES_USER=${POSTGRES_USER}"
+      - "POSTGRES_PASSWORD=${POSTGRES_PASSWORD}"
     ports:
       - 5432:5432
     networks:
@@ -36,6 +36,73 @@ services:
     restart: unless-stopped
     volumes:
       - db_data:/var/lib/postgresql/data
+
+  search:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.3.1
+    environment:
+      - "cluster.name=cleanspeak"
+      - "bootstrap.memory_lock=true"
+      - "ES_JAVA_OPTS=${ES_JAVA_OPTS}"
+    ports:
+      - 9200:9200
+      - 9300:9300
+    networks:
+      - search
+    restart: unless-stopped
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - es_data:/usr/share/elasticsearch/data
+
+  cleanspeak-webservice:
+    image: cleanspeak/cleanspeak-webservice:latest
+    depends_on:
+      - db
+      - search
+    environment:
+      - "DATABASE_URL=jdbc:postgresql://db:5432/cleanspeak"
+      - "DATABASE_ROOT_USER=${POSTGRES_USER}"
+      - "DATABASE_ROOT_PASSWORD=${POSTGRES_PASSWORD}"
+      - "DATABASE_USER=${DATABASE_USER}"
+      - "DATABASE_PASSWORD=${DATABASE_PASSWORD}"
+      - "CLEANSPEAK_MEMORY=${CLEANSPEAK_MEMORY}"
+      - "CLEANSPEAK_SEARCH_SERVERS=http://search:9200"
+      - "CLEANSPEAK_URL=http://cleanspeak-ws:8001"
+      - "LICENSE_ID=${LICENSE_ID}"
+    networks:
+      - db
+      - search
+    restart: unless-stopped
+    ports:
+      - 8001:8001
+    volumes:
+      - cs_config:/usr/local/inversoft/config
+
+  cleanspeak-management-interface:
+    image: cleanspeak/cleanspeak-management-interface:latest
+    depends_on:
+      - db
+      - search
+    environment:
+      - "DATABASE_URL=jdbc:postgresql://db:5432/cleanspeak"
+      - "DATABASE_ROOT_USER=${POSTGRES_USER}"
+      - "DATABASE_ROOT_PASSWORD=${POSTGRES_PASSWORD}"
+      - "DATABASE_USER=${DATABASE_USER}"
+      - "DATABASE_PASSWORD=${DATABASE_PASSWORD}"
+      - "CLEANSPEAK_MEMORY=${CLEANSPEAK_MEMORY}"
+      - "CLEANSPEAK_SEARCH_SERVERS=http://search:9200"
+      - "CLEANSPEAK_URL=http://cleanspeak-mi:9011"
+      - "LICENSE_ID=${LICENSE_ID}"
+    networks:
+      - db
+      - search
+    restart: unless-stopped
+    ports:
+      - 8011:8011
+    volumes:
+      - cs_config:/usr/local/inversoft/config
 
 networks:
   db:
@@ -46,4 +113,4 @@ networks:
 volumes:
   db_data:
   es_data:
-  fa_config:
+  cs_config:

--- a/prisma.yml
+++ b/prisma.yml
@@ -2,4 +2,5 @@ endpoint: http://localhost:4466
 datamodel: datamodel.prisma
 generate:
   - generator: javascript-client
-    output: ./generated/prisma-client/
+    output: ./src/generated/prisma-client/
+

--- a/src/generated/prisma-client/index.d.ts
+++ b/src/generated/prisma-client/index.d.ts
@@ -17,6 +17,7 @@ export type Maybe<T> = T | undefined | null;
 
 export interface Exists {
   group: (where?: GroupWhereInput) => Promise<boolean>;
+  moderation: (where?: ModerationWhereInput) => Promise<boolean>;
   post: (where?: PostWhereInput) => Promise<boolean>;
   thread: (where?: ThreadWhereInput) => Promise<boolean>;
 }
@@ -59,6 +60,25 @@ export interface Prisma {
     first?: Int;
     last?: Int;
   }) => GroupConnectionPromise;
+  moderation: (where: ModerationWhereUniqueInput) => ModerationNullablePromise;
+  moderations: (args?: {
+    where?: ModerationWhereInput;
+    orderBy?: ModerationOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => FragmentableArray<Moderation>;
+  moderationsConnection: (args?: {
+    where?: ModerationWhereInput;
+    orderBy?: ModerationOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => ModerationConnectionPromise;
   post: (where: PostWhereUniqueInput) => PostNullablePromise;
   posts: (args?: {
     where?: PostWhereInput;
@@ -119,6 +139,22 @@ export interface Prisma {
   }) => GroupPromise;
   deleteGroup: (where: GroupWhereUniqueInput) => GroupPromise;
   deleteManyGroups: (where?: GroupWhereInput) => BatchPayloadPromise;
+  createModeration: (data: ModerationCreateInput) => ModerationPromise;
+  updateModeration: (args: {
+    data: ModerationUpdateInput;
+    where: ModerationWhereUniqueInput;
+  }) => ModerationPromise;
+  updateManyModerations: (args: {
+    data: ModerationUpdateManyMutationInput;
+    where?: ModerationWhereInput;
+  }) => BatchPayloadPromise;
+  upsertModeration: (args: {
+    where: ModerationWhereUniqueInput;
+    create: ModerationCreateInput;
+    update: ModerationUpdateInput;
+  }) => ModerationPromise;
+  deleteModeration: (where: ModerationWhereUniqueInput) => ModerationPromise;
+  deleteManyModerations: (where?: ModerationWhereInput) => BatchPayloadPromise;
   createPost: (data: PostCreateInput) => PostPromise;
   updatePost: (args: {
     data: PostUpdateInput;
@@ -163,6 +199,9 @@ export interface Subscription {
   group: (
     where?: GroupSubscriptionWhereInput
   ) => GroupSubscriptionPayloadSubscription;
+  moderation: (
+    where?: ModerationSubscriptionWhereInput
+  ) => ModerationSubscriptionPayloadSubscription;
   post: (
     where?: PostSubscriptionWhereInput
   ) => PostSubscriptionPayloadSubscription;
@@ -179,6 +218,10 @@ export interface ClientConstructor<T> {
  * Types
  */
 
+export type ModerationStatus =
+  | "TRIGGERED_CONTENT_FILTER"
+  | "APPROVED_BY_MODERATOR";
+
 export type ThreadOrderByInput =
   | "id_ASC"
   | "id_DESC"
@@ -186,10 +229,6 @@ export type ThreadOrderByInput =
   | "createdAt_DESC"
   | "updatedAt_ASC"
   | "updatedAt_DESC"
-  | "abusive_ASC"
-  | "abusive_DESC"
-  | "published_ASC"
-  | "published_DESC"
   | "title_ASC"
   | "title_DESC";
 
@@ -200,12 +239,8 @@ export type PostOrderByInput =
   | "createdAt_DESC"
   | "updatedAt_ASC"
   | "updatedAt_DESC"
-  | "abusive_ASC"
-  | "abusive_DESC"
   | "content_ASC"
-  | "content_DESC"
-  | "published_ASC"
-  | "published_DESC";
+  | "content_DESC";
 
 export type GroupOrderByInput =
   | "id_ASC"
@@ -219,41 +254,37 @@ export type GroupOrderByInput =
   | "name_ASC"
   | "name_DESC";
 
+export type ModerationOrderByInput =
+  | "id_ASC"
+  | "id_DESC"
+  | "createdAt_ASC"
+  | "createdAt_DESC"
+  | "updatedAt_ASC"
+  | "updatedAt_DESC"
+  | "status_ASC"
+  | "status_DESC";
+
 export type MutationType = "CREATED" | "UPDATED" | "DELETED";
 
-export interface PostUpdateWithWhereUniqueWithoutThreadInput {
-  where: PostWhereUniqueInput;
-  data: PostUpdateWithoutThreadDataInput;
+export interface ModerationUpdateOneInput {
+  create?: Maybe<ModerationCreateInput>;
+  update?: Maybe<ModerationUpdateDataInput>;
+  upsert?: Maybe<ModerationUpsertNestedInput>;
+  delete?: Maybe<Boolean>;
+  disconnect?: Maybe<Boolean>;
+  connect?: Maybe<ModerationWhereUniqueInput>;
 }
 
 export type GroupWhereUniqueInput = AtLeastOne<{
   id: Maybe<ID_Input>;
 }>;
 
-export interface ThreadCreateManyWithoutGroupInput {
-  create?: Maybe<
-    ThreadCreateWithoutGroupInput[] | ThreadCreateWithoutGroupInput
-  >;
-  connect?: Maybe<ThreadWhereUniqueInput[] | ThreadWhereUniqueInput>;
+export interface PostUpdateWithWhereUniqueWithoutThreadInput {
+  where: PostWhereUniqueInput;
+  data: PostUpdateWithoutThreadDataInput;
 }
 
-export interface PostCreateInput {
-  id?: Maybe<ID_Input>;
-  abusive?: Maybe<Boolean>;
-  content: String;
-  published?: Maybe<Boolean>;
-  thread?: Maybe<ThreadCreateOneWithoutPostsInput>;
-}
-
-export interface ThreadCreateWithoutGroupInput {
-  id?: Maybe<ID_Input>;
-  abusive?: Maybe<Boolean>;
-  posts?: Maybe<PostCreateManyWithoutThreadInput>;
-  published?: Maybe<Boolean>;
-  title: String;
-}
-
-export interface PostScalarWhereInput {
+export interface ModerationWhereInput {
   id?: Maybe<ID_Input>;
   id_not?: Maybe<ID_Input>;
   id_in?: Maybe<ID_Input[] | ID_Input>;
@@ -284,285 +315,18 @@ export interface PostScalarWhereInput {
   updatedAt_lte?: Maybe<DateTimeInput>;
   updatedAt_gt?: Maybe<DateTimeInput>;
   updatedAt_gte?: Maybe<DateTimeInput>;
-  abusive?: Maybe<Boolean>;
-  abusive_not?: Maybe<Boolean>;
-  content?: Maybe<String>;
-  content_not?: Maybe<String>;
-  content_in?: Maybe<String[] | String>;
-  content_not_in?: Maybe<String[] | String>;
-  content_lt?: Maybe<String>;
-  content_lte?: Maybe<String>;
-  content_gt?: Maybe<String>;
-  content_gte?: Maybe<String>;
-  content_contains?: Maybe<String>;
-  content_not_contains?: Maybe<String>;
-  content_starts_with?: Maybe<String>;
-  content_not_starts_with?: Maybe<String>;
-  content_ends_with?: Maybe<String>;
-  content_not_ends_with?: Maybe<String>;
-  published?: Maybe<Boolean>;
-  published_not?: Maybe<Boolean>;
-  AND?: Maybe<PostScalarWhereInput[] | PostScalarWhereInput>;
-  OR?: Maybe<PostScalarWhereInput[] | PostScalarWhereInput>;
-  NOT?: Maybe<PostScalarWhereInput[] | PostScalarWhereInput>;
+  status?: Maybe<ModerationStatus>;
+  status_not?: Maybe<ModerationStatus>;
+  status_in?: Maybe<ModerationStatus[] | ModerationStatus>;
+  status_not_in?: Maybe<ModerationStatus[] | ModerationStatus>;
+  AND?: Maybe<ModerationWhereInput[] | ModerationWhereInput>;
+  OR?: Maybe<ModerationWhereInput[] | ModerationWhereInput>;
+  NOT?: Maybe<ModerationWhereInput[] | ModerationWhereInput>;
 }
-
-export interface PostCreateManyWithoutThreadInput {
-  create?: Maybe<PostCreateWithoutThreadInput[] | PostCreateWithoutThreadInput>;
-  connect?: Maybe<PostWhereUniqueInput[] | PostWhereUniqueInput>;
-}
-
-export interface ThreadWhereInput {
-  id?: Maybe<ID_Input>;
-  id_not?: Maybe<ID_Input>;
-  id_in?: Maybe<ID_Input[] | ID_Input>;
-  id_not_in?: Maybe<ID_Input[] | ID_Input>;
-  id_lt?: Maybe<ID_Input>;
-  id_lte?: Maybe<ID_Input>;
-  id_gt?: Maybe<ID_Input>;
-  id_gte?: Maybe<ID_Input>;
-  id_contains?: Maybe<ID_Input>;
-  id_not_contains?: Maybe<ID_Input>;
-  id_starts_with?: Maybe<ID_Input>;
-  id_not_starts_with?: Maybe<ID_Input>;
-  id_ends_with?: Maybe<ID_Input>;
-  id_not_ends_with?: Maybe<ID_Input>;
-  createdAt?: Maybe<DateTimeInput>;
-  createdAt_not?: Maybe<DateTimeInput>;
-  createdAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  createdAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  createdAt_lt?: Maybe<DateTimeInput>;
-  createdAt_lte?: Maybe<DateTimeInput>;
-  createdAt_gt?: Maybe<DateTimeInput>;
-  createdAt_gte?: Maybe<DateTimeInput>;
-  updatedAt?: Maybe<DateTimeInput>;
-  updatedAt_not?: Maybe<DateTimeInput>;
-  updatedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  updatedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  updatedAt_lt?: Maybe<DateTimeInput>;
-  updatedAt_lte?: Maybe<DateTimeInput>;
-  updatedAt_gt?: Maybe<DateTimeInput>;
-  updatedAt_gte?: Maybe<DateTimeInput>;
-  abusive?: Maybe<Boolean>;
-  abusive_not?: Maybe<Boolean>;
-  group?: Maybe<GroupWhereInput>;
-  posts_every?: Maybe<PostWhereInput>;
-  posts_some?: Maybe<PostWhereInput>;
-  posts_none?: Maybe<PostWhereInput>;
-  published?: Maybe<Boolean>;
-  published_not?: Maybe<Boolean>;
-  title?: Maybe<String>;
-  title_not?: Maybe<String>;
-  title_in?: Maybe<String[] | String>;
-  title_not_in?: Maybe<String[] | String>;
-  title_lt?: Maybe<String>;
-  title_lte?: Maybe<String>;
-  title_gt?: Maybe<String>;
-  title_gte?: Maybe<String>;
-  title_contains?: Maybe<String>;
-  title_not_contains?: Maybe<String>;
-  title_starts_with?: Maybe<String>;
-  title_not_starts_with?: Maybe<String>;
-  title_ends_with?: Maybe<String>;
-  title_not_ends_with?: Maybe<String>;
-  AND?: Maybe<ThreadWhereInput[] | ThreadWhereInput>;
-  OR?: Maybe<ThreadWhereInput[] | ThreadWhereInput>;
-  NOT?: Maybe<ThreadWhereInput[] | ThreadWhereInput>;
-}
-
-export interface PostCreateWithoutThreadInput {
-  id?: Maybe<ID_Input>;
-  abusive?: Maybe<Boolean>;
-  content: String;
-  published?: Maybe<Boolean>;
-}
-
-export interface PostSubscriptionWhereInput {
-  mutation_in?: Maybe<MutationType[] | MutationType>;
-  updatedFields_contains?: Maybe<String>;
-  updatedFields_contains_every?: Maybe<String[] | String>;
-  updatedFields_contains_some?: Maybe<String[] | String>;
-  node?: Maybe<PostWhereInput>;
-  AND?: Maybe<PostSubscriptionWhereInput[] | PostSubscriptionWhereInput>;
-  OR?: Maybe<PostSubscriptionWhereInput[] | PostSubscriptionWhereInput>;
-  NOT?: Maybe<PostSubscriptionWhereInput[] | PostSubscriptionWhereInput>;
-}
-
-export interface GroupUpdateInput {
-  description?: Maybe<String>;
-  name?: Maybe<String>;
-  threads?: Maybe<ThreadUpdateManyWithoutGroupInput>;
-}
-
-export interface ThreadUpdateManyMutationInput {
-  abusive?: Maybe<Boolean>;
-  published?: Maybe<Boolean>;
-  title?: Maybe<String>;
-}
-
-export interface ThreadUpdateManyWithoutGroupInput {
-  create?: Maybe<
-    ThreadCreateWithoutGroupInput[] | ThreadCreateWithoutGroupInput
-  >;
-  delete?: Maybe<ThreadWhereUniqueInput[] | ThreadWhereUniqueInput>;
-  connect?: Maybe<ThreadWhereUniqueInput[] | ThreadWhereUniqueInput>;
-  set?: Maybe<ThreadWhereUniqueInput[] | ThreadWhereUniqueInput>;
-  disconnect?: Maybe<ThreadWhereUniqueInput[] | ThreadWhereUniqueInput>;
-  update?: Maybe<
-    | ThreadUpdateWithWhereUniqueWithoutGroupInput[]
-    | ThreadUpdateWithWhereUniqueWithoutGroupInput
-  >;
-  upsert?: Maybe<
-    | ThreadUpsertWithWhereUniqueWithoutGroupInput[]
-    | ThreadUpsertWithWhereUniqueWithoutGroupInput
-  >;
-  deleteMany?: Maybe<ThreadScalarWhereInput[] | ThreadScalarWhereInput>;
-  updateMany?: Maybe<
-    | ThreadUpdateManyWithWhereNestedInput[]
-    | ThreadUpdateManyWithWhereNestedInput
-  >;
-}
-
-export interface ThreadCreateInput {
-  id?: Maybe<ID_Input>;
-  abusive?: Maybe<Boolean>;
-  group?: Maybe<GroupCreateOneWithoutThreadsInput>;
-  posts?: Maybe<PostCreateManyWithoutThreadInput>;
-  published?: Maybe<Boolean>;
-  title: String;
-}
-
-export interface ThreadUpdateWithWhereUniqueWithoutGroupInput {
-  where: ThreadWhereUniqueInput;
-  data: ThreadUpdateWithoutGroupDataInput;
-}
-
-export interface ThreadUpsertWithoutPostsInput {
-  update: ThreadUpdateWithoutPostsDataInput;
-  create: ThreadCreateWithoutPostsInput;
-}
-
-export interface ThreadUpdateWithoutGroupDataInput {
-  abusive?: Maybe<Boolean>;
-  posts?: Maybe<PostUpdateManyWithoutThreadInput>;
-  published?: Maybe<Boolean>;
-  title?: Maybe<String>;
-}
-
-export type PostWhereUniqueInput = AtLeastOne<{
-  id: Maybe<ID_Input>;
-}>;
-
-export interface PostUpdateManyWithoutThreadInput {
-  create?: Maybe<PostCreateWithoutThreadInput[] | PostCreateWithoutThreadInput>;
-  delete?: Maybe<PostWhereUniqueInput[] | PostWhereUniqueInput>;
-  connect?: Maybe<PostWhereUniqueInput[] | PostWhereUniqueInput>;
-  set?: Maybe<PostWhereUniqueInput[] | PostWhereUniqueInput>;
-  disconnect?: Maybe<PostWhereUniqueInput[] | PostWhereUniqueInput>;
-  update?: Maybe<
-    | PostUpdateWithWhereUniqueWithoutThreadInput[]
-    | PostUpdateWithWhereUniqueWithoutThreadInput
-  >;
-  upsert?: Maybe<
-    | PostUpsertWithWhereUniqueWithoutThreadInput[]
-    | PostUpsertWithWhereUniqueWithoutThreadInput
-  >;
-  deleteMany?: Maybe<PostScalarWhereInput[] | PostScalarWhereInput>;
-  updateMany?: Maybe<
-    PostUpdateManyWithWhereNestedInput[] | PostUpdateManyWithWhereNestedInput
-  >;
-}
-
-export interface GroupUpdateOneWithoutThreadsInput {
-  create?: Maybe<GroupCreateWithoutThreadsInput>;
-  update?: Maybe<GroupUpdateWithoutThreadsDataInput>;
-  upsert?: Maybe<GroupUpsertWithoutThreadsInput>;
-  delete?: Maybe<Boolean>;
-  disconnect?: Maybe<Boolean>;
-  connect?: Maybe<GroupWhereUniqueInput>;
-}
-
-export interface GroupCreateOneWithoutThreadsInput {
-  create?: Maybe<GroupCreateWithoutThreadsInput>;
-  connect?: Maybe<GroupWhereUniqueInput>;
-}
-
-export type ThreadWhereUniqueInput = AtLeastOne<{
-  id: Maybe<ID_Input>;
-}>;
 
 export interface PostUpdateWithoutThreadDataInput {
-  abusive?: Maybe<Boolean>;
   content?: Maybe<String>;
-  published?: Maybe<Boolean>;
-}
-
-export interface PostUpdateInput {
-  abusive?: Maybe<Boolean>;
-  content?: Maybe<String>;
-  published?: Maybe<Boolean>;
-  thread?: Maybe<ThreadUpdateOneWithoutPostsInput>;
-}
-
-export interface PostUpsertWithWhereUniqueWithoutThreadInput {
-  where: PostWhereUniqueInput;
-  update: PostUpdateWithoutThreadDataInput;
-  create: PostCreateWithoutThreadInput;
-}
-
-export interface PostWhereInput {
-  id?: Maybe<ID_Input>;
-  id_not?: Maybe<ID_Input>;
-  id_in?: Maybe<ID_Input[] | ID_Input>;
-  id_not_in?: Maybe<ID_Input[] | ID_Input>;
-  id_lt?: Maybe<ID_Input>;
-  id_lte?: Maybe<ID_Input>;
-  id_gt?: Maybe<ID_Input>;
-  id_gte?: Maybe<ID_Input>;
-  id_contains?: Maybe<ID_Input>;
-  id_not_contains?: Maybe<ID_Input>;
-  id_starts_with?: Maybe<ID_Input>;
-  id_not_starts_with?: Maybe<ID_Input>;
-  id_ends_with?: Maybe<ID_Input>;
-  id_not_ends_with?: Maybe<ID_Input>;
-  createdAt?: Maybe<DateTimeInput>;
-  createdAt_not?: Maybe<DateTimeInput>;
-  createdAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  createdAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  createdAt_lt?: Maybe<DateTimeInput>;
-  createdAt_lte?: Maybe<DateTimeInput>;
-  createdAt_gt?: Maybe<DateTimeInput>;
-  createdAt_gte?: Maybe<DateTimeInput>;
-  updatedAt?: Maybe<DateTimeInput>;
-  updatedAt_not?: Maybe<DateTimeInput>;
-  updatedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  updatedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  updatedAt_lt?: Maybe<DateTimeInput>;
-  updatedAt_lte?: Maybe<DateTimeInput>;
-  updatedAt_gt?: Maybe<DateTimeInput>;
-  updatedAt_gte?: Maybe<DateTimeInput>;
-  abusive?: Maybe<Boolean>;
-  abusive_not?: Maybe<Boolean>;
-  content?: Maybe<String>;
-  content_not?: Maybe<String>;
-  content_in?: Maybe<String[] | String>;
-  content_not_in?: Maybe<String[] | String>;
-  content_lt?: Maybe<String>;
-  content_lte?: Maybe<String>;
-  content_gt?: Maybe<String>;
-  content_gte?: Maybe<String>;
-  content_contains?: Maybe<String>;
-  content_not_contains?: Maybe<String>;
-  content_starts_with?: Maybe<String>;
-  content_not_starts_with?: Maybe<String>;
-  content_ends_with?: Maybe<String>;
-  content_not_ends_with?: Maybe<String>;
-  published?: Maybe<Boolean>;
-  published_not?: Maybe<Boolean>;
-  thread?: Maybe<ThreadWhereInput>;
-  AND?: Maybe<PostWhereInput[] | PostWhereInput>;
-  OR?: Maybe<PostWhereInput[] | PostWhereInput>;
-  NOT?: Maybe<PostWhereInput[] | PostWhereInput>;
+  moderation?: Maybe<ModerationUpdateOneInput>;
 }
 
 export interface GroupWhereInput {
@@ -632,6 +396,370 @@ export interface GroupWhereInput {
   NOT?: Maybe<GroupWhereInput[] | GroupWhereInput>;
 }
 
+export interface ThreadCreateWithoutGroupInput {
+  id?: Maybe<ID_Input>;
+  moderation?: Maybe<ModerationCreateOneInput>;
+  posts?: Maybe<PostCreateManyWithoutThreadInput>;
+  title: String;
+}
+
+export interface ModerationUpdateInput {
+  status?: Maybe<ModerationStatus>;
+}
+
+export interface ModerationCreateOneInput {
+  create?: Maybe<ModerationCreateInput>;
+  connect?: Maybe<ModerationWhereUniqueInput>;
+}
+
+export interface PostUpsertWithWhereUniqueWithoutThreadInput {
+  where: PostWhereUniqueInput;
+  update: PostUpdateWithoutThreadDataInput;
+  create: PostCreateWithoutThreadInput;
+}
+
+export interface ModerationCreateInput {
+  id?: Maybe<ID_Input>;
+  status: ModerationStatus;
+}
+
+export interface ThreadSubscriptionWhereInput {
+  mutation_in?: Maybe<MutationType[] | MutationType>;
+  updatedFields_contains?: Maybe<String>;
+  updatedFields_contains_every?: Maybe<String[] | String>;
+  updatedFields_contains_some?: Maybe<String[] | String>;
+  node?: Maybe<ThreadWhereInput>;
+  AND?: Maybe<ThreadSubscriptionWhereInput[] | ThreadSubscriptionWhereInput>;
+  OR?: Maybe<ThreadSubscriptionWhereInput[] | ThreadSubscriptionWhereInput>;
+  NOT?: Maybe<ThreadSubscriptionWhereInput[] | ThreadSubscriptionWhereInput>;
+}
+
+export interface PostCreateManyWithoutThreadInput {
+  create?: Maybe<PostCreateWithoutThreadInput[] | PostCreateWithoutThreadInput>;
+  connect?: Maybe<PostWhereUniqueInput[] | PostWhereUniqueInput>;
+}
+
+export interface ModerationSubscriptionWhereInput {
+  mutation_in?: Maybe<MutationType[] | MutationType>;
+  updatedFields_contains?: Maybe<String>;
+  updatedFields_contains_every?: Maybe<String[] | String>;
+  updatedFields_contains_some?: Maybe<String[] | String>;
+  node?: Maybe<ModerationWhereInput>;
+  AND?: Maybe<
+    ModerationSubscriptionWhereInput[] | ModerationSubscriptionWhereInput
+  >;
+  OR?: Maybe<
+    ModerationSubscriptionWhereInput[] | ModerationSubscriptionWhereInput
+  >;
+  NOT?: Maybe<
+    ModerationSubscriptionWhereInput[] | ModerationSubscriptionWhereInput
+  >;
+}
+
+export interface PostCreateWithoutThreadInput {
+  id?: Maybe<ID_Input>;
+  content: String;
+  moderation?: Maybe<ModerationCreateOneInput>;
+}
+
+export interface ThreadUpdateManyMutationInput {
+  title?: Maybe<String>;
+}
+
+export interface GroupUpdateInput {
+  description?: Maybe<String>;
+  name?: Maybe<String>;
+  threads?: Maybe<ThreadUpdateManyWithoutGroupInput>;
+}
+
+export interface ThreadCreateInput {
+  id?: Maybe<ID_Input>;
+  group?: Maybe<GroupCreateOneWithoutThreadsInput>;
+  moderation?: Maybe<ModerationCreateOneInput>;
+  posts?: Maybe<PostCreateManyWithoutThreadInput>;
+  title: String;
+}
+
+export interface ThreadUpdateManyWithoutGroupInput {
+  create?: Maybe<
+    ThreadCreateWithoutGroupInput[] | ThreadCreateWithoutGroupInput
+  >;
+  delete?: Maybe<ThreadWhereUniqueInput[] | ThreadWhereUniqueInput>;
+  connect?: Maybe<ThreadWhereUniqueInput[] | ThreadWhereUniqueInput>;
+  set?: Maybe<ThreadWhereUniqueInput[] | ThreadWhereUniqueInput>;
+  disconnect?: Maybe<ThreadWhereUniqueInput[] | ThreadWhereUniqueInput>;
+  update?: Maybe<
+    | ThreadUpdateWithWhereUniqueWithoutGroupInput[]
+    | ThreadUpdateWithWhereUniqueWithoutGroupInput
+  >;
+  upsert?: Maybe<
+    | ThreadUpsertWithWhereUniqueWithoutGroupInput[]
+    | ThreadUpsertWithWhereUniqueWithoutGroupInput
+  >;
+  deleteMany?: Maybe<ThreadScalarWhereInput[] | ThreadScalarWhereInput>;
+  updateMany?: Maybe<
+    | ThreadUpdateManyWithWhereNestedInput[]
+    | ThreadUpdateManyWithWhereNestedInput
+  >;
+}
+
+export interface PostUpdateManyMutationInput {
+  content?: Maybe<String>;
+}
+
+export interface ThreadUpdateWithWhereUniqueWithoutGroupInput {
+  where: ThreadWhereUniqueInput;
+  data: ThreadUpdateWithoutGroupDataInput;
+}
+
+export interface GroupUpsertWithoutThreadsInput {
+  update: GroupUpdateWithoutThreadsDataInput;
+  create: GroupCreateWithoutThreadsInput;
+}
+
+export interface ThreadUpdateWithoutGroupDataInput {
+  moderation?: Maybe<ModerationUpdateOneInput>;
+  posts?: Maybe<PostUpdateManyWithoutThreadInput>;
+  title?: Maybe<String>;
+}
+
+export type PostWhereUniqueInput = AtLeastOne<{
+  id: Maybe<ID_Input>;
+}>;
+
+export interface ThreadCreateWithoutPostsInput {
+  id?: Maybe<ID_Input>;
+  group?: Maybe<GroupCreateOneWithoutThreadsInput>;
+  moderation?: Maybe<ModerationCreateOneInput>;
+  title: String;
+}
+
+export interface ThreadUpdateWithoutPostsDataInput {
+  group?: Maybe<GroupUpdateOneWithoutThreadsInput>;
+  moderation?: Maybe<ModerationUpdateOneInput>;
+  title?: Maybe<String>;
+}
+
+export interface ModerationUpdateDataInput {
+  status?: Maybe<ModerationStatus>;
+}
+
+export type ThreadWhereUniqueInput = AtLeastOne<{
+  id: Maybe<ID_Input>;
+}>;
+
+export interface ModerationUpsertNestedInput {
+  update: ModerationUpdateDataInput;
+  create: ModerationCreateInput;
+}
+
+export interface GroupCreateWithoutThreadsInput {
+  id?: Maybe<ID_Input>;
+  description: String;
+  name: String;
+}
+
+export interface PostUpdateManyWithoutThreadInput {
+  create?: Maybe<PostCreateWithoutThreadInput[] | PostCreateWithoutThreadInput>;
+  delete?: Maybe<PostWhereUniqueInput[] | PostWhereUniqueInput>;
+  connect?: Maybe<PostWhereUniqueInput[] | PostWhereUniqueInput>;
+  set?: Maybe<PostWhereUniqueInput[] | PostWhereUniqueInput>;
+  disconnect?: Maybe<PostWhereUniqueInput[] | PostWhereUniqueInput>;
+  update?: Maybe<
+    | PostUpdateWithWhereUniqueWithoutThreadInput[]
+    | PostUpdateWithWhereUniqueWithoutThreadInput
+  >;
+  upsert?: Maybe<
+    | PostUpsertWithWhereUniqueWithoutThreadInput[]
+    | PostUpsertWithWhereUniqueWithoutThreadInput
+  >;
+  deleteMany?: Maybe<PostScalarWhereInput[] | PostScalarWhereInput>;
+  updateMany?: Maybe<
+    PostUpdateManyWithWhereNestedInput[] | PostUpdateManyWithWhereNestedInput
+  >;
+}
+
+export interface ThreadCreateManyWithoutGroupInput {
+  create?: Maybe<
+    ThreadCreateWithoutGroupInput[] | ThreadCreateWithoutGroupInput
+  >;
+  connect?: Maybe<ThreadWhereUniqueInput[] | ThreadWhereUniqueInput>;
+}
+
+export interface PostWhereInput {
+  id?: Maybe<ID_Input>;
+  id_not?: Maybe<ID_Input>;
+  id_in?: Maybe<ID_Input[] | ID_Input>;
+  id_not_in?: Maybe<ID_Input[] | ID_Input>;
+  id_lt?: Maybe<ID_Input>;
+  id_lte?: Maybe<ID_Input>;
+  id_gt?: Maybe<ID_Input>;
+  id_gte?: Maybe<ID_Input>;
+  id_contains?: Maybe<ID_Input>;
+  id_not_contains?: Maybe<ID_Input>;
+  id_starts_with?: Maybe<ID_Input>;
+  id_not_starts_with?: Maybe<ID_Input>;
+  id_ends_with?: Maybe<ID_Input>;
+  id_not_ends_with?: Maybe<ID_Input>;
+  createdAt?: Maybe<DateTimeInput>;
+  createdAt_not?: Maybe<DateTimeInput>;
+  createdAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  createdAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  createdAt_lt?: Maybe<DateTimeInput>;
+  createdAt_lte?: Maybe<DateTimeInput>;
+  createdAt_gt?: Maybe<DateTimeInput>;
+  createdAt_gte?: Maybe<DateTimeInput>;
+  updatedAt?: Maybe<DateTimeInput>;
+  updatedAt_not?: Maybe<DateTimeInput>;
+  updatedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  updatedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  updatedAt_lt?: Maybe<DateTimeInput>;
+  updatedAt_lte?: Maybe<DateTimeInput>;
+  updatedAt_gt?: Maybe<DateTimeInput>;
+  updatedAt_gte?: Maybe<DateTimeInput>;
+  content?: Maybe<String>;
+  content_not?: Maybe<String>;
+  content_in?: Maybe<String[] | String>;
+  content_not_in?: Maybe<String[] | String>;
+  content_lt?: Maybe<String>;
+  content_lte?: Maybe<String>;
+  content_gt?: Maybe<String>;
+  content_gte?: Maybe<String>;
+  content_contains?: Maybe<String>;
+  content_not_contains?: Maybe<String>;
+  content_starts_with?: Maybe<String>;
+  content_not_starts_with?: Maybe<String>;
+  content_ends_with?: Maybe<String>;
+  content_not_ends_with?: Maybe<String>;
+  moderation?: Maybe<ModerationWhereInput>;
+  thread?: Maybe<ThreadWhereInput>;
+  AND?: Maybe<PostWhereInput[] | PostWhereInput>;
+  OR?: Maybe<PostWhereInput[] | PostWhereInput>;
+  NOT?: Maybe<PostWhereInput[] | PostWhereInput>;
+}
+
+export interface PostSubscriptionWhereInput {
+  mutation_in?: Maybe<MutationType[] | MutationType>;
+  updatedFields_contains?: Maybe<String>;
+  updatedFields_contains_every?: Maybe<String[] | String>;
+  updatedFields_contains_some?: Maybe<String[] | String>;
+  node?: Maybe<PostWhereInput>;
+  AND?: Maybe<PostSubscriptionWhereInput[] | PostSubscriptionWhereInput>;
+  OR?: Maybe<PostSubscriptionWhereInput[] | PostSubscriptionWhereInput>;
+  NOT?: Maybe<PostSubscriptionWhereInput[] | PostSubscriptionWhereInput>;
+}
+
+export interface ThreadCreateOneWithoutPostsInput {
+  create?: Maybe<ThreadCreateWithoutPostsInput>;
+  connect?: Maybe<ThreadWhereUniqueInput>;
+}
+
+export interface ThreadUpdateInput {
+  group?: Maybe<GroupUpdateOneWithoutThreadsInput>;
+  moderation?: Maybe<ModerationUpdateOneInput>;
+  posts?: Maybe<PostUpdateManyWithoutThreadInput>;
+  title?: Maybe<String>;
+}
+
+export interface PostCreateInput {
+  id?: Maybe<ID_Input>;
+  content: String;
+  moderation?: Maybe<ModerationCreateOneInput>;
+  thread?: Maybe<ThreadCreateOneWithoutPostsInput>;
+}
+
+export interface ThreadUpsertWithoutPostsInput {
+  update: ThreadUpdateWithoutPostsDataInput;
+  create: ThreadCreateWithoutPostsInput;
+}
+
+export interface PostScalarWhereInput {
+  id?: Maybe<ID_Input>;
+  id_not?: Maybe<ID_Input>;
+  id_in?: Maybe<ID_Input[] | ID_Input>;
+  id_not_in?: Maybe<ID_Input[] | ID_Input>;
+  id_lt?: Maybe<ID_Input>;
+  id_lte?: Maybe<ID_Input>;
+  id_gt?: Maybe<ID_Input>;
+  id_gte?: Maybe<ID_Input>;
+  id_contains?: Maybe<ID_Input>;
+  id_not_contains?: Maybe<ID_Input>;
+  id_starts_with?: Maybe<ID_Input>;
+  id_not_starts_with?: Maybe<ID_Input>;
+  id_ends_with?: Maybe<ID_Input>;
+  id_not_ends_with?: Maybe<ID_Input>;
+  createdAt?: Maybe<DateTimeInput>;
+  createdAt_not?: Maybe<DateTimeInput>;
+  createdAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  createdAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  createdAt_lt?: Maybe<DateTimeInput>;
+  createdAt_lte?: Maybe<DateTimeInput>;
+  createdAt_gt?: Maybe<DateTimeInput>;
+  createdAt_gte?: Maybe<DateTimeInput>;
+  updatedAt?: Maybe<DateTimeInput>;
+  updatedAt_not?: Maybe<DateTimeInput>;
+  updatedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  updatedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  updatedAt_lt?: Maybe<DateTimeInput>;
+  updatedAt_lte?: Maybe<DateTimeInput>;
+  updatedAt_gt?: Maybe<DateTimeInput>;
+  updatedAt_gte?: Maybe<DateTimeInput>;
+  content?: Maybe<String>;
+  content_not?: Maybe<String>;
+  content_in?: Maybe<String[] | String>;
+  content_not_in?: Maybe<String[] | String>;
+  content_lt?: Maybe<String>;
+  content_lte?: Maybe<String>;
+  content_gt?: Maybe<String>;
+  content_gte?: Maybe<String>;
+  content_contains?: Maybe<String>;
+  content_not_contains?: Maybe<String>;
+  content_starts_with?: Maybe<String>;
+  content_not_starts_with?: Maybe<String>;
+  content_ends_with?: Maybe<String>;
+  content_not_ends_with?: Maybe<String>;
+  AND?: Maybe<PostScalarWhereInput[] | PostScalarWhereInput>;
+  OR?: Maybe<PostScalarWhereInput[] | PostScalarWhereInput>;
+  NOT?: Maybe<PostScalarWhereInput[] | PostScalarWhereInput>;
+}
+
+export interface GroupUpdateOneWithoutThreadsInput {
+  create?: Maybe<GroupCreateWithoutThreadsInput>;
+  update?: Maybe<GroupUpdateWithoutThreadsDataInput>;
+  upsert?: Maybe<GroupUpsertWithoutThreadsInput>;
+  delete?: Maybe<Boolean>;
+  disconnect?: Maybe<Boolean>;
+  connect?: Maybe<GroupWhereUniqueInput>;
+}
+
+export interface PostUpdateManyWithWhereNestedInput {
+  where: PostScalarWhereInput;
+  data: PostUpdateManyDataInput;
+}
+
+export interface PostUpdateInput {
+  content?: Maybe<String>;
+  moderation?: Maybe<ModerationUpdateOneInput>;
+  thread?: Maybe<ThreadUpdateOneWithoutPostsInput>;
+}
+
+export interface PostUpdateManyDataInput {
+  content?: Maybe<String>;
+}
+
+export interface GroupCreateInput {
+  id?: Maybe<ID_Input>;
+  description: String;
+  name: String;
+  threads?: Maybe<ThreadCreateManyWithoutGroupInput>;
+}
+
+export interface ThreadUpsertWithWhereUniqueWithoutGroupInput {
+  where: ThreadWhereUniqueInput;
+  update: ThreadUpdateWithoutGroupDataInput;
+  create: ThreadCreateWithoutGroupInput;
+}
+
 export interface GroupSubscriptionWhereInput {
   mutation_in?: Maybe<MutationType[] | MutationType>;
   updatedFields_contains?: Maybe<String>;
@@ -641,43 +769,6 @@ export interface GroupSubscriptionWhereInput {
   AND?: Maybe<GroupSubscriptionWhereInput[] | GroupSubscriptionWhereInput>;
   OR?: Maybe<GroupSubscriptionWhereInput[] | GroupSubscriptionWhereInput>;
   NOT?: Maybe<GroupSubscriptionWhereInput[] | GroupSubscriptionWhereInput>;
-}
-
-export interface PostUpdateManyWithWhereNestedInput {
-  where: PostScalarWhereInput;
-  data: PostUpdateManyDataInput;
-}
-
-export interface PostUpdateManyMutationInput {
-  abusive?: Maybe<Boolean>;
-  content?: Maybe<String>;
-  published?: Maybe<Boolean>;
-}
-
-export interface PostUpdateManyDataInput {
-  abusive?: Maybe<Boolean>;
-  content?: Maybe<String>;
-  published?: Maybe<Boolean>;
-}
-
-export interface GroupUpdateWithoutThreadsDataInput {
-  description?: Maybe<String>;
-  name?: Maybe<String>;
-}
-
-export interface ThreadUpsertWithWhereUniqueWithoutGroupInput {
-  where: ThreadWhereUniqueInput;
-  update: ThreadUpdateWithoutGroupDataInput;
-  create: ThreadCreateWithoutGroupInput;
-}
-
-export interface ThreadUpdateOneWithoutPostsInput {
-  create?: Maybe<ThreadCreateWithoutPostsInput>;
-  update?: Maybe<ThreadUpdateWithoutPostsDataInput>;
-  upsert?: Maybe<ThreadUpsertWithoutPostsInput>;
-  delete?: Maybe<Boolean>;
-  disconnect?: Maybe<Boolean>;
-  connect?: Maybe<ThreadWhereUniqueInput>;
 }
 
 export interface ThreadScalarWhereInput {
@@ -711,10 +802,6 @@ export interface ThreadScalarWhereInput {
   updatedAt_lte?: Maybe<DateTimeInput>;
   updatedAt_gt?: Maybe<DateTimeInput>;
   updatedAt_gte?: Maybe<DateTimeInput>;
-  abusive?: Maybe<Boolean>;
-  abusive_not?: Maybe<Boolean>;
-  published?: Maybe<Boolean>;
-  published_not?: Maybe<Boolean>;
   title?: Maybe<String>;
   title_not?: Maybe<String>;
   title_in?: Maybe<String[] | String>;
@@ -734,37 +821,13 @@ export interface ThreadScalarWhereInput {
   NOT?: Maybe<ThreadScalarWhereInput[] | ThreadScalarWhereInput>;
 }
 
-export interface GroupCreateInput {
-  id?: Maybe<ID_Input>;
-  description: String;
-  name: String;
-  threads?: Maybe<ThreadCreateManyWithoutGroupInput>;
+export interface GroupUpdateWithoutThreadsDataInput {
+  description?: Maybe<String>;
+  name?: Maybe<String>;
 }
 
-export interface ThreadUpdateManyWithWhereNestedInput {
-  where: ThreadScalarWhereInput;
-  data: ThreadUpdateManyDataInput;
-}
-
-export interface ThreadUpdateInput {
-  abusive?: Maybe<Boolean>;
-  group?: Maybe<GroupUpdateOneWithoutThreadsInput>;
-  posts?: Maybe<PostUpdateManyWithoutThreadInput>;
-  published?: Maybe<Boolean>;
-  title?: Maybe<String>;
-}
-
-export interface ThreadCreateOneWithoutPostsInput {
-  create?: Maybe<ThreadCreateWithoutPostsInput>;
-  connect?: Maybe<ThreadWhereUniqueInput>;
-}
-
-export interface ThreadCreateWithoutPostsInput {
-  id?: Maybe<ID_Input>;
-  abusive?: Maybe<Boolean>;
-  group?: Maybe<GroupCreateOneWithoutThreadsInput>;
-  published?: Maybe<Boolean>;
-  title: String;
+export interface ModerationUpdateManyMutationInput {
+  status?: Maybe<ModerationStatus>;
 }
 
 export interface GroupUpdateManyMutationInput {
@@ -773,38 +836,85 @@ export interface GroupUpdateManyMutationInput {
 }
 
 export interface ThreadUpdateManyDataInput {
-  abusive?: Maybe<Boolean>;
-  published?: Maybe<Boolean>;
   title?: Maybe<String>;
 }
 
-export interface GroupUpsertWithoutThreadsInput {
-  update: GroupUpdateWithoutThreadsDataInput;
-  create: GroupCreateWithoutThreadsInput;
+export interface ThreadUpdateManyWithWhereNestedInput {
+  where: ThreadScalarWhereInput;
+  data: ThreadUpdateManyDataInput;
 }
 
-export interface ThreadSubscriptionWhereInput {
-  mutation_in?: Maybe<MutationType[] | MutationType>;
-  updatedFields_contains?: Maybe<String>;
-  updatedFields_contains_every?: Maybe<String[] | String>;
-  updatedFields_contains_some?: Maybe<String[] | String>;
-  node?: Maybe<ThreadWhereInput>;
-  AND?: Maybe<ThreadSubscriptionWhereInput[] | ThreadSubscriptionWhereInput>;
-  OR?: Maybe<ThreadSubscriptionWhereInput[] | ThreadSubscriptionWhereInput>;
-  NOT?: Maybe<ThreadSubscriptionWhereInput[] | ThreadSubscriptionWhereInput>;
+export interface ThreadUpdateOneWithoutPostsInput {
+  create?: Maybe<ThreadCreateWithoutPostsInput>;
+  update?: Maybe<ThreadUpdateWithoutPostsDataInput>;
+  upsert?: Maybe<ThreadUpsertWithoutPostsInput>;
+  delete?: Maybe<Boolean>;
+  disconnect?: Maybe<Boolean>;
+  connect?: Maybe<ThreadWhereUniqueInput>;
 }
 
-export interface GroupCreateWithoutThreadsInput {
+export type ModerationWhereUniqueInput = AtLeastOne<{
+  id: Maybe<ID_Input>;
+}>;
+
+export interface ThreadWhereInput {
   id?: Maybe<ID_Input>;
-  description: String;
-  name: String;
+  id_not?: Maybe<ID_Input>;
+  id_in?: Maybe<ID_Input[] | ID_Input>;
+  id_not_in?: Maybe<ID_Input[] | ID_Input>;
+  id_lt?: Maybe<ID_Input>;
+  id_lte?: Maybe<ID_Input>;
+  id_gt?: Maybe<ID_Input>;
+  id_gte?: Maybe<ID_Input>;
+  id_contains?: Maybe<ID_Input>;
+  id_not_contains?: Maybe<ID_Input>;
+  id_starts_with?: Maybe<ID_Input>;
+  id_not_starts_with?: Maybe<ID_Input>;
+  id_ends_with?: Maybe<ID_Input>;
+  id_not_ends_with?: Maybe<ID_Input>;
+  createdAt?: Maybe<DateTimeInput>;
+  createdAt_not?: Maybe<DateTimeInput>;
+  createdAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  createdAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  createdAt_lt?: Maybe<DateTimeInput>;
+  createdAt_lte?: Maybe<DateTimeInput>;
+  createdAt_gt?: Maybe<DateTimeInput>;
+  createdAt_gte?: Maybe<DateTimeInput>;
+  updatedAt?: Maybe<DateTimeInput>;
+  updatedAt_not?: Maybe<DateTimeInput>;
+  updatedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  updatedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  updatedAt_lt?: Maybe<DateTimeInput>;
+  updatedAt_lte?: Maybe<DateTimeInput>;
+  updatedAt_gt?: Maybe<DateTimeInput>;
+  updatedAt_gte?: Maybe<DateTimeInput>;
+  group?: Maybe<GroupWhereInput>;
+  moderation?: Maybe<ModerationWhereInput>;
+  posts_every?: Maybe<PostWhereInput>;
+  posts_some?: Maybe<PostWhereInput>;
+  posts_none?: Maybe<PostWhereInput>;
+  title?: Maybe<String>;
+  title_not?: Maybe<String>;
+  title_in?: Maybe<String[] | String>;
+  title_not_in?: Maybe<String[] | String>;
+  title_lt?: Maybe<String>;
+  title_lte?: Maybe<String>;
+  title_gt?: Maybe<String>;
+  title_gte?: Maybe<String>;
+  title_contains?: Maybe<String>;
+  title_not_contains?: Maybe<String>;
+  title_starts_with?: Maybe<String>;
+  title_not_starts_with?: Maybe<String>;
+  title_ends_with?: Maybe<String>;
+  title_not_ends_with?: Maybe<String>;
+  AND?: Maybe<ThreadWhereInput[] | ThreadWhereInput>;
+  OR?: Maybe<ThreadWhereInput[] | ThreadWhereInput>;
+  NOT?: Maybe<ThreadWhereInput[] | ThreadWhereInput>;
 }
 
-export interface ThreadUpdateWithoutPostsDataInput {
-  abusive?: Maybe<Boolean>;
-  group?: Maybe<GroupUpdateOneWithoutThreadsInput>;
-  published?: Maybe<Boolean>;
-  title?: Maybe<String>;
+export interface GroupCreateOneWithoutThreadsInput {
+  create?: Maybe<GroupCreateWithoutThreadsInput>;
+  connect?: Maybe<GroupWhereUniqueInput>;
 }
 
 export interface NodeNode {
@@ -815,8 +925,6 @@ export interface ThreadPreviousValues {
   id: ID_Output;
   createdAt: DateTimeOutput;
   updatedAt: DateTimeOutput;
-  abusive: Boolean;
-  published: Boolean;
   title: String;
 }
 
@@ -826,8 +934,6 @@ export interface ThreadPreviousValuesPromise
   id: () => Promise<ID_Output>;
   createdAt: () => Promise<DateTimeOutput>;
   updatedAt: () => Promise<DateTimeOutput>;
-  abusive: () => Promise<Boolean>;
-  published: () => Promise<Boolean>;
   title: () => Promise<String>;
 }
 
@@ -837,9 +943,88 @@ export interface ThreadPreviousValuesSubscription
   id: () => Promise<AsyncIterator<ID_Output>>;
   createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
   updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  abusive: () => Promise<AsyncIterator<Boolean>>;
-  published: () => Promise<AsyncIterator<Boolean>>;
   title: () => Promise<AsyncIterator<String>>;
+}
+
+export interface AggregateGroup {
+  count: Int;
+}
+
+export interface AggregateGroupPromise
+  extends Promise<AggregateGroup>,
+    Fragmentable {
+  count: () => Promise<Int>;
+}
+
+export interface AggregateGroupSubscription
+  extends Promise<AsyncIterator<AggregateGroup>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface Thread {
+  id: ID_Output;
+  createdAt: DateTimeOutput;
+  updatedAt: DateTimeOutput;
+  title: String;
+}
+
+export interface ThreadPromise extends Promise<Thread>, Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  group: <T = GroupPromise>() => T;
+  moderation: <T = ModerationPromise>() => T;
+  posts: <T = FragmentableArray<Post>>(args?: {
+    where?: PostWhereInput;
+    orderBy?: PostOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  title: () => Promise<String>;
+}
+
+export interface ThreadSubscription
+  extends Promise<AsyncIterator<Thread>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  group: <T = GroupSubscription>() => T;
+  moderation: <T = ModerationSubscription>() => T;
+  posts: <T = Promise<AsyncIterator<PostSubscription>>>(args?: {
+    where?: PostWhereInput;
+    orderBy?: PostOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  title: () => Promise<AsyncIterator<String>>;
+}
+
+export interface ThreadNullablePromise
+  extends Promise<Thread | null>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  group: <T = GroupPromise>() => T;
+  moderation: <T = ModerationPromise>() => T;
+  posts: <T = FragmentableArray<Post>>(args?: {
+    where?: PostWhereInput;
+    orderBy?: PostOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  title: () => Promise<String>;
 }
 
 export interface GroupEdge {
@@ -859,74 +1044,136 @@ export interface GroupEdgeSubscription
   cursor: () => Promise<AsyncIterator<String>>;
 }
 
-export interface Thread {
+export interface Moderation {
   id: ID_Output;
   createdAt: DateTimeOutput;
   updatedAt: DateTimeOutput;
-  abusive: Boolean;
-  published: Boolean;
-  title: String;
+  status: ModerationStatus;
 }
 
-export interface ThreadPromise extends Promise<Thread>, Fragmentable {
+export interface ModerationPromise extends Promise<Moderation>, Fragmentable {
   id: () => Promise<ID_Output>;
   createdAt: () => Promise<DateTimeOutput>;
   updatedAt: () => Promise<DateTimeOutput>;
-  abusive: () => Promise<Boolean>;
-  group: <T = GroupPromise>() => T;
-  posts: <T = FragmentableArray<Post>>(args?: {
-    where?: PostWhereInput;
-    orderBy?: PostOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-  published: () => Promise<Boolean>;
-  title: () => Promise<String>;
+  status: () => Promise<ModerationStatus>;
 }
 
-export interface ThreadSubscription
-  extends Promise<AsyncIterator<Thread>>,
+export interface ModerationSubscription
+  extends Promise<AsyncIterator<Moderation>>,
     Fragmentable {
   id: () => Promise<AsyncIterator<ID_Output>>;
   createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
   updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  abusive: () => Promise<AsyncIterator<Boolean>>;
-  group: <T = GroupSubscription>() => T;
-  posts: <T = Promise<AsyncIterator<PostSubscription>>>(args?: {
-    where?: PostWhereInput;
-    orderBy?: PostOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-  published: () => Promise<AsyncIterator<Boolean>>;
-  title: () => Promise<AsyncIterator<String>>;
+  status: () => Promise<AsyncIterator<ModerationStatus>>;
 }
 
-export interface ThreadNullablePromise
-  extends Promise<Thread | null>,
+export interface ModerationNullablePromise
+  extends Promise<Moderation | null>,
     Fragmentable {
   id: () => Promise<ID_Output>;
   createdAt: () => Promise<DateTimeOutput>;
   updatedAt: () => Promise<DateTimeOutput>;
-  abusive: () => Promise<Boolean>;
-  group: <T = GroupPromise>() => T;
-  posts: <T = FragmentableArray<Post>>(args?: {
-    where?: PostWhereInput;
-    orderBy?: PostOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-  published: () => Promise<Boolean>;
-  title: () => Promise<String>;
+  status: () => Promise<ModerationStatus>;
+}
+
+export interface Post {
+  id: ID_Output;
+  createdAt: DateTimeOutput;
+  updatedAt: DateTimeOutput;
+  content: String;
+}
+
+export interface PostPromise extends Promise<Post>, Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  content: () => Promise<String>;
+  moderation: <T = ModerationPromise>() => T;
+  thread: <T = ThreadPromise>() => T;
+}
+
+export interface PostSubscription
+  extends Promise<AsyncIterator<Post>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  content: () => Promise<AsyncIterator<String>>;
+  moderation: <T = ModerationSubscription>() => T;
+  thread: <T = ThreadSubscription>() => T;
+}
+
+export interface PostNullablePromise
+  extends Promise<Post | null>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  content: () => Promise<String>;
+  moderation: <T = ModerationPromise>() => T;
+  thread: <T = ThreadPromise>() => T;
+}
+
+export interface PostSubscriptionPayload {
+  mutation: MutationType;
+  node: Post;
+  updatedFields: String[];
+  previousValues: PostPreviousValues;
+}
+
+export interface PostSubscriptionPayloadPromise
+  extends Promise<PostSubscriptionPayload>,
+    Fragmentable {
+  mutation: () => Promise<MutationType>;
+  node: <T = PostPromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = PostPreviousValuesPromise>() => T;
+}
+
+export interface PostSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<PostSubscriptionPayload>>,
+    Fragmentable {
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = PostSubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = PostPreviousValuesSubscription>() => T;
+}
+
+export interface AggregateThread {
+  count: Int;
+}
+
+export interface AggregateThreadPromise
+  extends Promise<AggregateThread>,
+    Fragmentable {
+  count: () => Promise<Int>;
+}
+
+export interface AggregateThreadSubscription
+  extends Promise<AsyncIterator<AggregateThread>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface ThreadConnection {
+  pageInfo: PageInfo;
+  edges: ThreadEdge[];
+}
+
+export interface ThreadConnectionPromise
+  extends Promise<ThreadConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<ThreadEdge>>() => T;
+  aggregate: <T = AggregateThreadPromise>() => T;
+}
+
+export interface ThreadConnectionSubscription
+  extends Promise<AsyncIterator<ThreadConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<ThreadEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateThreadSubscription>() => T;
 }
 
 export interface PageInfo {
@@ -952,154 +1199,6 @@ export interface PageInfoSubscription
   endCursor: () => Promise<AsyncIterator<String>>;
 }
 
-export interface GroupConnection {
-  pageInfo: PageInfo;
-  edges: GroupEdge[];
-}
-
-export interface GroupConnectionPromise
-  extends Promise<GroupConnection>,
-    Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<GroupEdge>>() => T;
-  aggregate: <T = AggregateGroupPromise>() => T;
-}
-
-export interface GroupConnectionSubscription
-  extends Promise<AsyncIterator<GroupConnection>>,
-    Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<GroupEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateGroupSubscription>() => T;
-}
-
-export interface BatchPayload {
-  count: Long;
-}
-
-export interface BatchPayloadPromise
-  extends Promise<BatchPayload>,
-    Fragmentable {
-  count: () => Promise<Long>;
-}
-
-export interface BatchPayloadSubscription
-  extends Promise<AsyncIterator<BatchPayload>>,
-    Fragmentable {
-  count: () => Promise<AsyncIterator<Long>>;
-}
-
-export interface AggregateThread {
-  count: Int;
-}
-
-export interface AggregateThreadPromise
-  extends Promise<AggregateThread>,
-    Fragmentable {
-  count: () => Promise<Int>;
-}
-
-export interface AggregateThreadSubscription
-  extends Promise<AsyncIterator<AggregateThread>>,
-    Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
-}
-
-export interface PostPreviousValues {
-  id: ID_Output;
-  createdAt: DateTimeOutput;
-  updatedAt: DateTimeOutput;
-  abusive: Boolean;
-  content: String;
-  published: Boolean;
-}
-
-export interface PostPreviousValuesPromise
-  extends Promise<PostPreviousValues>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  createdAt: () => Promise<DateTimeOutput>;
-  updatedAt: () => Promise<DateTimeOutput>;
-  abusive: () => Promise<Boolean>;
-  content: () => Promise<String>;
-  published: () => Promise<Boolean>;
-}
-
-export interface PostPreviousValuesSubscription
-  extends Promise<AsyncIterator<PostPreviousValues>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  abusive: () => Promise<AsyncIterator<Boolean>>;
-  content: () => Promise<AsyncIterator<String>>;
-  published: () => Promise<AsyncIterator<Boolean>>;
-}
-
-export interface ThreadConnection {
-  pageInfo: PageInfo;
-  edges: ThreadEdge[];
-}
-
-export interface ThreadConnectionPromise
-  extends Promise<ThreadConnection>,
-    Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<ThreadEdge>>() => T;
-  aggregate: <T = AggregateThreadPromise>() => T;
-}
-
-export interface ThreadConnectionSubscription
-  extends Promise<AsyncIterator<ThreadConnection>>,
-    Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<ThreadEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateThreadSubscription>() => T;
-}
-
-export interface Post {
-  id: ID_Output;
-  createdAt: DateTimeOutput;
-  updatedAt: DateTimeOutput;
-  abusive: Boolean;
-  content: String;
-  published: Boolean;
-}
-
-export interface PostPromise extends Promise<Post>, Fragmentable {
-  id: () => Promise<ID_Output>;
-  createdAt: () => Promise<DateTimeOutput>;
-  updatedAt: () => Promise<DateTimeOutput>;
-  abusive: () => Promise<Boolean>;
-  content: () => Promise<String>;
-  published: () => Promise<Boolean>;
-  thread: <T = ThreadPromise>() => T;
-}
-
-export interface PostSubscription
-  extends Promise<AsyncIterator<Post>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  abusive: () => Promise<AsyncIterator<Boolean>>;
-  content: () => Promise<AsyncIterator<String>>;
-  published: () => Promise<AsyncIterator<Boolean>>;
-  thread: <T = ThreadSubscription>() => T;
-}
-
-export interface PostNullablePromise
-  extends Promise<Post | null>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  createdAt: () => Promise<DateTimeOutput>;
-  updatedAt: () => Promise<DateTimeOutput>;
-  abusive: () => Promise<Boolean>;
-  content: () => Promise<String>;
-  published: () => Promise<Boolean>;
-  thread: <T = ThreadPromise>() => T;
-}
-
 export interface PostEdge {
   node: Post;
   cursor: String;
@@ -1115,75 +1214,6 @@ export interface PostEdgeSubscription
     Fragmentable {
   node: <T = PostSubscription>() => T;
   cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface AggregateGroup {
-  count: Int;
-}
-
-export interface AggregateGroupPromise
-  extends Promise<AggregateGroup>,
-    Fragmentable {
-  count: () => Promise<Int>;
-}
-
-export interface AggregateGroupSubscription
-  extends Promise<AsyncIterator<AggregateGroup>>,
-    Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
-}
-
-export interface GroupPreviousValues {
-  id: ID_Output;
-  createdAt: DateTimeOutput;
-  updatedAt: DateTimeOutput;
-  description: String;
-  name: String;
-}
-
-export interface GroupPreviousValuesPromise
-  extends Promise<GroupPreviousValues>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  createdAt: () => Promise<DateTimeOutput>;
-  updatedAt: () => Promise<DateTimeOutput>;
-  description: () => Promise<String>;
-  name: () => Promise<String>;
-}
-
-export interface GroupPreviousValuesSubscription
-  extends Promise<AsyncIterator<GroupPreviousValues>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  description: () => Promise<AsyncIterator<String>>;
-  name: () => Promise<AsyncIterator<String>>;
-}
-
-export interface GroupSubscriptionPayload {
-  mutation: MutationType;
-  node: Group;
-  updatedFields: String[];
-  previousValues: GroupPreviousValues;
-}
-
-export interface GroupSubscriptionPayloadPromise
-  extends Promise<GroupSubscriptionPayload>,
-    Fragmentable {
-  mutation: () => Promise<MutationType>;
-  node: <T = GroupPromise>() => T;
-  updatedFields: () => Promise<String[]>;
-  previousValues: <T = GroupPreviousValuesPromise>() => T;
-}
-
-export interface GroupSubscriptionPayloadSubscription
-  extends Promise<AsyncIterator<GroupSubscriptionPayload>>,
-    Fragmentable {
-  mutation: () => Promise<AsyncIterator<MutationType>>;
-  node: <T = GroupSubscription>() => T;
-  updatedFields: () => Promise<AsyncIterator<String[]>>;
-  previousValues: <T = GroupPreviousValuesSubscription>() => T;
 }
 
 export interface Group {
@@ -1249,29 +1279,223 @@ export interface GroupNullablePromise
   }) => T;
 }
 
-export interface PostSubscriptionPayload {
-  mutation: MutationType;
-  node: Post;
-  updatedFields: String[];
-  previousValues: PostPreviousValues;
+export interface AggregateModeration {
+  count: Int;
 }
 
-export interface PostSubscriptionPayloadPromise
-  extends Promise<PostSubscriptionPayload>,
+export interface AggregateModerationPromise
+  extends Promise<AggregateModeration>,
+    Fragmentable {
+  count: () => Promise<Int>;
+}
+
+export interface AggregateModerationSubscription
+  extends Promise<AsyncIterator<AggregateModeration>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface GroupSubscriptionPayload {
+  mutation: MutationType;
+  node: Group;
+  updatedFields: String[];
+  previousValues: GroupPreviousValues;
+}
+
+export interface GroupSubscriptionPayloadPromise
+  extends Promise<GroupSubscriptionPayload>,
     Fragmentable {
   mutation: () => Promise<MutationType>;
-  node: <T = PostPromise>() => T;
+  node: <T = GroupPromise>() => T;
   updatedFields: () => Promise<String[]>;
-  previousValues: <T = PostPreviousValuesPromise>() => T;
+  previousValues: <T = GroupPreviousValuesPromise>() => T;
 }
 
-export interface PostSubscriptionPayloadSubscription
-  extends Promise<AsyncIterator<PostSubscriptionPayload>>,
+export interface GroupSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<GroupSubscriptionPayload>>,
     Fragmentable {
   mutation: () => Promise<AsyncIterator<MutationType>>;
-  node: <T = PostSubscription>() => T;
+  node: <T = GroupSubscription>() => T;
   updatedFields: () => Promise<AsyncIterator<String[]>>;
-  previousValues: <T = PostPreviousValuesSubscription>() => T;
+  previousValues: <T = GroupPreviousValuesSubscription>() => T;
+}
+
+export interface ModerationConnection {
+  pageInfo: PageInfo;
+  edges: ModerationEdge[];
+}
+
+export interface ModerationConnectionPromise
+  extends Promise<ModerationConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<ModerationEdge>>() => T;
+  aggregate: <T = AggregateModerationPromise>() => T;
+}
+
+export interface ModerationConnectionSubscription
+  extends Promise<AsyncIterator<ModerationConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<ModerationEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateModerationSubscription>() => T;
+}
+
+export interface GroupPreviousValues {
+  id: ID_Output;
+  createdAt: DateTimeOutput;
+  updatedAt: DateTimeOutput;
+  description: String;
+  name: String;
+}
+
+export interface GroupPreviousValuesPromise
+  extends Promise<GroupPreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  description: () => Promise<String>;
+  name: () => Promise<String>;
+}
+
+export interface GroupPreviousValuesSubscription
+  extends Promise<AsyncIterator<GroupPreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  description: () => Promise<AsyncIterator<String>>;
+  name: () => Promise<AsyncIterator<String>>;
+}
+
+export interface BatchPayload {
+  count: Long;
+}
+
+export interface BatchPayloadPromise
+  extends Promise<BatchPayload>,
+    Fragmentable {
+  count: () => Promise<Long>;
+}
+
+export interface BatchPayloadSubscription
+  extends Promise<AsyncIterator<BatchPayload>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Long>>;
+}
+
+export interface PostPreviousValues {
+  id: ID_Output;
+  createdAt: DateTimeOutput;
+  updatedAt: DateTimeOutput;
+  content: String;
+}
+
+export interface PostPreviousValuesPromise
+  extends Promise<PostPreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  content: () => Promise<String>;
+}
+
+export interface PostPreviousValuesSubscription
+  extends Promise<AsyncIterator<PostPreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  content: () => Promise<AsyncIterator<String>>;
+}
+
+export interface ModerationPreviousValues {
+  id: ID_Output;
+  createdAt: DateTimeOutput;
+  updatedAt: DateTimeOutput;
+  status: ModerationStatus;
+}
+
+export interface ModerationPreviousValuesPromise
+  extends Promise<ModerationPreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  status: () => Promise<ModerationStatus>;
+}
+
+export interface ModerationPreviousValuesSubscription
+  extends Promise<AsyncIterator<ModerationPreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  status: () => Promise<AsyncIterator<ModerationStatus>>;
+}
+
+export interface ModerationSubscriptionPayload {
+  mutation: MutationType;
+  node: Moderation;
+  updatedFields: String[];
+  previousValues: ModerationPreviousValues;
+}
+
+export interface ModerationSubscriptionPayloadPromise
+  extends Promise<ModerationSubscriptionPayload>,
+    Fragmentable {
+  mutation: () => Promise<MutationType>;
+  node: <T = ModerationPromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = ModerationPreviousValuesPromise>() => T;
+}
+
+export interface ModerationSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<ModerationSubscriptionPayload>>,
+    Fragmentable {
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = ModerationSubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = ModerationPreviousValuesSubscription>() => T;
+}
+
+export interface GroupConnection {
+  pageInfo: PageInfo;
+  edges: GroupEdge[];
+}
+
+export interface GroupConnectionPromise
+  extends Promise<GroupConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<GroupEdge>>() => T;
+  aggregate: <T = AggregateGroupPromise>() => T;
+}
+
+export interface GroupConnectionSubscription
+  extends Promise<AsyncIterator<GroupConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<GroupEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateGroupSubscription>() => T;
+}
+
+export interface ThreadEdge {
+  node: Thread;
+  cursor: String;
+}
+
+export interface ThreadEdgePromise extends Promise<ThreadEdge>, Fragmentable {
+  node: <T = ThreadPromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface ThreadEdgeSubscription
+  extends Promise<AsyncIterator<ThreadEdge>>,
+    Fragmentable {
+  node: <T = ThreadSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
 }
 
 export interface ThreadSubscriptionPayload {
@@ -1297,6 +1521,25 @@ export interface ThreadSubscriptionPayloadSubscription
   node: <T = ThreadSubscription>() => T;
   updatedFields: () => Promise<AsyncIterator<String[]>>;
   previousValues: <T = ThreadPreviousValuesSubscription>() => T;
+}
+
+export interface ModerationEdge {
+  node: Moderation;
+  cursor: String;
+}
+
+export interface ModerationEdgePromise
+  extends Promise<ModerationEdge>,
+    Fragmentable {
+  node: <T = ModerationPromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface ModerationEdgeSubscription
+  extends Promise<AsyncIterator<ModerationEdge>>,
+    Fragmentable {
+  node: <T = ModerationSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
 }
 
 export interface PostConnection {
@@ -1336,23 +1579,6 @@ export interface AggregatePostSubscription
   count: () => Promise<AsyncIterator<Int>>;
 }
 
-export interface ThreadEdge {
-  node: Thread;
-  cursor: String;
-}
-
-export interface ThreadEdgePromise extends Promise<ThreadEdge>, Fragmentable {
-  node: <T = ThreadPromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface ThreadEdgeSubscription
-  extends Promise<AsyncIterator<ThreadEdge>>,
-    Fragmentable {
-  node: <T = ThreadSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
 /*
 The `Boolean` scalar type represents `true` or `false`.
 */
@@ -1367,11 +1593,6 @@ export type ID_Input = string | number;
 export type ID_Output = string;
 
 /*
-The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. 
-*/
-export type Int = number;
-
-/*
 DateTime scalar input type, allowing Date
 */
 export type DateTimeInput = Date | string;
@@ -1380,6 +1601,11 @@ export type DateTimeInput = Date | string;
 DateTime scalar output type, which is always a string
 */
 export type DateTimeOutput = string;
+
+/*
+The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. 
+*/
+export type Int = number;
 
 /*
 The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.
@@ -1392,15 +1618,23 @@ export type String = string;
 
 export const models: Model[] = [
   {
+    name: "ModerationStatus",
+    embedded: false
+  },
+  {
+    name: "Moderation",
+    embedded: false
+  },
+  {
+    name: "Group",
+    embedded: false
+  },
+  {
     name: "Post",
     embedded: false
   },
   {
     name: "Thread",
-    embedded: false
-  },
-  {
-    name: "Group",
     embedded: false
   }
 ];

--- a/src/generated/prisma-client/index.d.ts
+++ b/src/generated/prisma-client/index.d.ts
@@ -218,10 +218,6 @@ export interface ClientConstructor<T> {
  * Types
  */
 
-export type ModerationStatus =
-  | "TRIGGERED_CONTENT_FILTER"
-  | "APPROVED_BY_MODERATOR";
-
 export type ThreadOrderByInput =
   | "id_ASC"
   | "id_DESC"
@@ -231,6 +227,10 @@ export type ThreadOrderByInput =
   | "updatedAt_DESC"
   | "title_ASC"
   | "title_DESC";
+
+export type ModerationStatus =
+  | "TRIGGERED_CONTENT_FILTER"
+  | "APPROVED_BY_MODERATOR";
 
 export type PostOrderByInput =
   | "id_ASC"
@@ -266,13 +266,27 @@ export type ModerationOrderByInput =
 
 export type MutationType = "CREATED" | "UPDATED" | "DELETED";
 
-export interface ModerationUpdateOneInput {
-  create?: Maybe<ModerationCreateInput>;
-  update?: Maybe<ModerationUpdateDataInput>;
-  upsert?: Maybe<ModerationUpsertNestedInput>;
-  delete?: Maybe<Boolean>;
-  disconnect?: Maybe<Boolean>;
-  connect?: Maybe<ModerationWhereUniqueInput>;
+export interface ThreadUpdateManyWithoutGroupInput {
+  create?: Maybe<
+    ThreadCreateWithoutGroupInput[] | ThreadCreateWithoutGroupInput
+  >;
+  delete?: Maybe<ThreadWhereUniqueInput[] | ThreadWhereUniqueInput>;
+  connect?: Maybe<ThreadWhereUniqueInput[] | ThreadWhereUniqueInput>;
+  set?: Maybe<ThreadWhereUniqueInput[] | ThreadWhereUniqueInput>;
+  disconnect?: Maybe<ThreadWhereUniqueInput[] | ThreadWhereUniqueInput>;
+  update?: Maybe<
+    | ThreadUpdateWithWhereUniqueWithoutGroupInput[]
+    | ThreadUpdateWithWhereUniqueWithoutGroupInput
+  >;
+  upsert?: Maybe<
+    | ThreadUpsertWithWhereUniqueWithoutGroupInput[]
+    | ThreadUpsertWithWhereUniqueWithoutGroupInput
+  >;
+  deleteMany?: Maybe<ThreadScalarWhereInput[] | ThreadScalarWhereInput>;
+  updateMany?: Maybe<
+    | ThreadUpdateManyWithWhereNestedInput[]
+    | ThreadUpdateManyWithWhereNestedInput
+  >;
 }
 
 export type GroupWhereUniqueInput = AtLeastOne<{
@@ -282,51 +296,6 @@ export type GroupWhereUniqueInput = AtLeastOne<{
 export interface PostUpdateWithWhereUniqueWithoutThreadInput {
   where: PostWhereUniqueInput;
   data: PostUpdateWithoutThreadDataInput;
-}
-
-export interface ModerationWhereInput {
-  id?: Maybe<ID_Input>;
-  id_not?: Maybe<ID_Input>;
-  id_in?: Maybe<ID_Input[] | ID_Input>;
-  id_not_in?: Maybe<ID_Input[] | ID_Input>;
-  id_lt?: Maybe<ID_Input>;
-  id_lte?: Maybe<ID_Input>;
-  id_gt?: Maybe<ID_Input>;
-  id_gte?: Maybe<ID_Input>;
-  id_contains?: Maybe<ID_Input>;
-  id_not_contains?: Maybe<ID_Input>;
-  id_starts_with?: Maybe<ID_Input>;
-  id_not_starts_with?: Maybe<ID_Input>;
-  id_ends_with?: Maybe<ID_Input>;
-  id_not_ends_with?: Maybe<ID_Input>;
-  createdAt?: Maybe<DateTimeInput>;
-  createdAt_not?: Maybe<DateTimeInput>;
-  createdAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  createdAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  createdAt_lt?: Maybe<DateTimeInput>;
-  createdAt_lte?: Maybe<DateTimeInput>;
-  createdAt_gt?: Maybe<DateTimeInput>;
-  createdAt_gte?: Maybe<DateTimeInput>;
-  updatedAt?: Maybe<DateTimeInput>;
-  updatedAt_not?: Maybe<DateTimeInput>;
-  updatedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  updatedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  updatedAt_lt?: Maybe<DateTimeInput>;
-  updatedAt_lte?: Maybe<DateTimeInput>;
-  updatedAt_gt?: Maybe<DateTimeInput>;
-  updatedAt_gte?: Maybe<DateTimeInput>;
-  status?: Maybe<ModerationStatus>;
-  status_not?: Maybe<ModerationStatus>;
-  status_in?: Maybe<ModerationStatus[] | ModerationStatus>;
-  status_not_in?: Maybe<ModerationStatus[] | ModerationStatus>;
-  AND?: Maybe<ModerationWhereInput[] | ModerationWhereInput>;
-  OR?: Maybe<ModerationWhereInput[] | ModerationWhereInput>;
-  NOT?: Maybe<ModerationWhereInput[] | ModerationWhereInput>;
-}
-
-export interface PostUpdateWithoutThreadDataInput {
-  content?: Maybe<String>;
-  moderation?: Maybe<ModerationUpdateOneInput>;
 }
 
 export interface GroupWhereInput {
@@ -374,6 +343,7 @@ export interface GroupWhereInput {
   description_not_starts_with?: Maybe<String>;
   description_ends_with?: Maybe<String>;
   description_not_ends_with?: Maybe<String>;
+  moderation?: Maybe<ModerationWhereInput>;
   name?: Maybe<String>;
   name_not?: Maybe<String>;
   name_in?: Maybe<String[] | String>;
@@ -396,194 +366,9 @@ export interface GroupWhereInput {
   NOT?: Maybe<GroupWhereInput[] | GroupWhereInput>;
 }
 
-export interface ThreadCreateWithoutGroupInput {
-  id?: Maybe<ID_Input>;
-  moderation?: Maybe<ModerationCreateOneInput>;
-  posts?: Maybe<PostCreateManyWithoutThreadInput>;
-  title: String;
-}
-
-export interface ModerationUpdateInput {
-  status?: Maybe<ModerationStatus>;
-}
-
-export interface ModerationCreateOneInput {
-  create?: Maybe<ModerationCreateInput>;
-  connect?: Maybe<ModerationWhereUniqueInput>;
-}
-
-export interface PostUpsertWithWhereUniqueWithoutThreadInput {
-  where: PostWhereUniqueInput;
-  update: PostUpdateWithoutThreadDataInput;
-  create: PostCreateWithoutThreadInput;
-}
-
-export interface ModerationCreateInput {
-  id?: Maybe<ID_Input>;
-  status: ModerationStatus;
-}
-
-export interface ThreadSubscriptionWhereInput {
-  mutation_in?: Maybe<MutationType[] | MutationType>;
-  updatedFields_contains?: Maybe<String>;
-  updatedFields_contains_every?: Maybe<String[] | String>;
-  updatedFields_contains_some?: Maybe<String[] | String>;
-  node?: Maybe<ThreadWhereInput>;
-  AND?: Maybe<ThreadSubscriptionWhereInput[] | ThreadSubscriptionWhereInput>;
-  OR?: Maybe<ThreadSubscriptionWhereInput[] | ThreadSubscriptionWhereInput>;
-  NOT?: Maybe<ThreadSubscriptionWhereInput[] | ThreadSubscriptionWhereInput>;
-}
-
-export interface PostCreateManyWithoutThreadInput {
-  create?: Maybe<PostCreateWithoutThreadInput[] | PostCreateWithoutThreadInput>;
-  connect?: Maybe<PostWhereUniqueInput[] | PostWhereUniqueInput>;
-}
-
-export interface ModerationSubscriptionWhereInput {
-  mutation_in?: Maybe<MutationType[] | MutationType>;
-  updatedFields_contains?: Maybe<String>;
-  updatedFields_contains_every?: Maybe<String[] | String>;
-  updatedFields_contains_some?: Maybe<String[] | String>;
-  node?: Maybe<ModerationWhereInput>;
-  AND?: Maybe<
-    ModerationSubscriptionWhereInput[] | ModerationSubscriptionWhereInput
-  >;
-  OR?: Maybe<
-    ModerationSubscriptionWhereInput[] | ModerationSubscriptionWhereInput
-  >;
-  NOT?: Maybe<
-    ModerationSubscriptionWhereInput[] | ModerationSubscriptionWhereInput
-  >;
-}
-
-export interface PostCreateWithoutThreadInput {
-  id?: Maybe<ID_Input>;
-  content: String;
-  moderation?: Maybe<ModerationCreateOneInput>;
-}
-
-export interface ThreadUpdateManyMutationInput {
-  title?: Maybe<String>;
-}
-
-export interface GroupUpdateInput {
-  description?: Maybe<String>;
-  name?: Maybe<String>;
-  threads?: Maybe<ThreadUpdateManyWithoutGroupInput>;
-}
-
-export interface ThreadCreateInput {
-  id?: Maybe<ID_Input>;
-  group?: Maybe<GroupCreateOneWithoutThreadsInput>;
-  moderation?: Maybe<ModerationCreateOneInput>;
-  posts?: Maybe<PostCreateManyWithoutThreadInput>;
-  title: String;
-}
-
-export interface ThreadUpdateManyWithoutGroupInput {
-  create?: Maybe<
-    ThreadCreateWithoutGroupInput[] | ThreadCreateWithoutGroupInput
-  >;
-  delete?: Maybe<ThreadWhereUniqueInput[] | ThreadWhereUniqueInput>;
-  connect?: Maybe<ThreadWhereUniqueInput[] | ThreadWhereUniqueInput>;
-  set?: Maybe<ThreadWhereUniqueInput[] | ThreadWhereUniqueInput>;
-  disconnect?: Maybe<ThreadWhereUniqueInput[] | ThreadWhereUniqueInput>;
-  update?: Maybe<
-    | ThreadUpdateWithWhereUniqueWithoutGroupInput[]
-    | ThreadUpdateWithWhereUniqueWithoutGroupInput
-  >;
-  upsert?: Maybe<
-    | ThreadUpsertWithWhereUniqueWithoutGroupInput[]
-    | ThreadUpsertWithWhereUniqueWithoutGroupInput
-  >;
-  deleteMany?: Maybe<ThreadScalarWhereInput[] | ThreadScalarWhereInput>;
-  updateMany?: Maybe<
-    | ThreadUpdateManyWithWhereNestedInput[]
-    | ThreadUpdateManyWithWhereNestedInput
-  >;
-}
-
-export interface PostUpdateManyMutationInput {
+export interface PostUpdateWithoutThreadDataInput {
   content?: Maybe<String>;
-}
-
-export interface ThreadUpdateWithWhereUniqueWithoutGroupInput {
-  where: ThreadWhereUniqueInput;
-  data: ThreadUpdateWithoutGroupDataInput;
-}
-
-export interface GroupUpsertWithoutThreadsInput {
-  update: GroupUpdateWithoutThreadsDataInput;
-  create: GroupCreateWithoutThreadsInput;
-}
-
-export interface ThreadUpdateWithoutGroupDataInput {
   moderation?: Maybe<ModerationUpdateOneInput>;
-  posts?: Maybe<PostUpdateManyWithoutThreadInput>;
-  title?: Maybe<String>;
-}
-
-export type PostWhereUniqueInput = AtLeastOne<{
-  id: Maybe<ID_Input>;
-}>;
-
-export interface ThreadCreateWithoutPostsInput {
-  id?: Maybe<ID_Input>;
-  group?: Maybe<GroupCreateOneWithoutThreadsInput>;
-  moderation?: Maybe<ModerationCreateOneInput>;
-  title: String;
-}
-
-export interface ThreadUpdateWithoutPostsDataInput {
-  group?: Maybe<GroupUpdateOneWithoutThreadsInput>;
-  moderation?: Maybe<ModerationUpdateOneInput>;
-  title?: Maybe<String>;
-}
-
-export interface ModerationUpdateDataInput {
-  status?: Maybe<ModerationStatus>;
-}
-
-export type ThreadWhereUniqueInput = AtLeastOne<{
-  id: Maybe<ID_Input>;
-}>;
-
-export interface ModerationUpsertNestedInput {
-  update: ModerationUpdateDataInput;
-  create: ModerationCreateInput;
-}
-
-export interface GroupCreateWithoutThreadsInput {
-  id?: Maybe<ID_Input>;
-  description: String;
-  name: String;
-}
-
-export interface PostUpdateManyWithoutThreadInput {
-  create?: Maybe<PostCreateWithoutThreadInput[] | PostCreateWithoutThreadInput>;
-  delete?: Maybe<PostWhereUniqueInput[] | PostWhereUniqueInput>;
-  connect?: Maybe<PostWhereUniqueInput[] | PostWhereUniqueInput>;
-  set?: Maybe<PostWhereUniqueInput[] | PostWhereUniqueInput>;
-  disconnect?: Maybe<PostWhereUniqueInput[] | PostWhereUniqueInput>;
-  update?: Maybe<
-    | PostUpdateWithWhereUniqueWithoutThreadInput[]
-    | PostUpdateWithWhereUniqueWithoutThreadInput
-  >;
-  upsert?: Maybe<
-    | PostUpsertWithWhereUniqueWithoutThreadInput[]
-    | PostUpsertWithWhereUniqueWithoutThreadInput
-  >;
-  deleteMany?: Maybe<PostScalarWhereInput[] | PostScalarWhereInput>;
-  updateMany?: Maybe<
-    PostUpdateManyWithWhereNestedInput[] | PostUpdateManyWithWhereNestedInput
-  >;
-}
-
-export interface ThreadCreateManyWithoutGroupInput {
-  create?: Maybe<
-    ThreadCreateWithoutGroupInput[] | ThreadCreateWithoutGroupInput
-  >;
-  connect?: Maybe<ThreadWhereUniqueInput[] | ThreadWhereUniqueInput>;
 }
 
 export interface PostWhereInput {
@@ -638,6 +423,35 @@ export interface PostWhereInput {
   NOT?: Maybe<PostWhereInput[] | PostWhereInput>;
 }
 
+export interface ModerationCreateInput {
+  id?: Maybe<ID_Input>;
+  status: ModerationStatus;
+}
+
+export interface ModerationUpdateInput {
+  status?: Maybe<ModerationStatus>;
+}
+
+export interface ThreadCreateManyWithoutGroupInput {
+  create?: Maybe<
+    ThreadCreateWithoutGroupInput[] | ThreadCreateWithoutGroupInput
+  >;
+  connect?: Maybe<ThreadWhereUniqueInput[] | ThreadWhereUniqueInput>;
+}
+
+export interface PostUpsertWithWhereUniqueWithoutThreadInput {
+  where: PostWhereUniqueInput;
+  update: PostUpdateWithoutThreadDataInput;
+  create: PostCreateWithoutThreadInput;
+}
+
+export interface ThreadCreateWithoutGroupInput {
+  id?: Maybe<ID_Input>;
+  moderation?: Maybe<ModerationCreateOneInput>;
+  posts?: Maybe<PostCreateManyWithoutThreadInput>;
+  title: String;
+}
+
 export interface PostSubscriptionWhereInput {
   mutation_in?: Maybe<MutationType[] | MutationType>;
   updatedFields_contains?: Maybe<String>;
@@ -649,115 +463,9 @@ export interface PostSubscriptionWhereInput {
   NOT?: Maybe<PostSubscriptionWhereInput[] | PostSubscriptionWhereInput>;
 }
 
-export interface ThreadCreateOneWithoutPostsInput {
-  create?: Maybe<ThreadCreateWithoutPostsInput>;
-  connect?: Maybe<ThreadWhereUniqueInput>;
-}
-
-export interface ThreadUpdateInput {
-  group?: Maybe<GroupUpdateOneWithoutThreadsInput>;
-  moderation?: Maybe<ModerationUpdateOneInput>;
-  posts?: Maybe<PostUpdateManyWithoutThreadInput>;
-  title?: Maybe<String>;
-}
-
-export interface PostCreateInput {
-  id?: Maybe<ID_Input>;
-  content: String;
-  moderation?: Maybe<ModerationCreateOneInput>;
-  thread?: Maybe<ThreadCreateOneWithoutPostsInput>;
-}
-
-export interface ThreadUpsertWithoutPostsInput {
-  update: ThreadUpdateWithoutPostsDataInput;
-  create: ThreadCreateWithoutPostsInput;
-}
-
-export interface PostScalarWhereInput {
-  id?: Maybe<ID_Input>;
-  id_not?: Maybe<ID_Input>;
-  id_in?: Maybe<ID_Input[] | ID_Input>;
-  id_not_in?: Maybe<ID_Input[] | ID_Input>;
-  id_lt?: Maybe<ID_Input>;
-  id_lte?: Maybe<ID_Input>;
-  id_gt?: Maybe<ID_Input>;
-  id_gte?: Maybe<ID_Input>;
-  id_contains?: Maybe<ID_Input>;
-  id_not_contains?: Maybe<ID_Input>;
-  id_starts_with?: Maybe<ID_Input>;
-  id_not_starts_with?: Maybe<ID_Input>;
-  id_ends_with?: Maybe<ID_Input>;
-  id_not_ends_with?: Maybe<ID_Input>;
-  createdAt?: Maybe<DateTimeInput>;
-  createdAt_not?: Maybe<DateTimeInput>;
-  createdAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  createdAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  createdAt_lt?: Maybe<DateTimeInput>;
-  createdAt_lte?: Maybe<DateTimeInput>;
-  createdAt_gt?: Maybe<DateTimeInput>;
-  createdAt_gte?: Maybe<DateTimeInput>;
-  updatedAt?: Maybe<DateTimeInput>;
-  updatedAt_not?: Maybe<DateTimeInput>;
-  updatedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  updatedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  updatedAt_lt?: Maybe<DateTimeInput>;
-  updatedAt_lte?: Maybe<DateTimeInput>;
-  updatedAt_gt?: Maybe<DateTimeInput>;
-  updatedAt_gte?: Maybe<DateTimeInput>;
-  content?: Maybe<String>;
-  content_not?: Maybe<String>;
-  content_in?: Maybe<String[] | String>;
-  content_not_in?: Maybe<String[] | String>;
-  content_lt?: Maybe<String>;
-  content_lte?: Maybe<String>;
-  content_gt?: Maybe<String>;
-  content_gte?: Maybe<String>;
-  content_contains?: Maybe<String>;
-  content_not_contains?: Maybe<String>;
-  content_starts_with?: Maybe<String>;
-  content_not_starts_with?: Maybe<String>;
-  content_ends_with?: Maybe<String>;
-  content_not_ends_with?: Maybe<String>;
-  AND?: Maybe<PostScalarWhereInput[] | PostScalarWhereInput>;
-  OR?: Maybe<PostScalarWhereInput[] | PostScalarWhereInput>;
-  NOT?: Maybe<PostScalarWhereInput[] | PostScalarWhereInput>;
-}
-
-export interface GroupUpdateOneWithoutThreadsInput {
-  create?: Maybe<GroupCreateWithoutThreadsInput>;
-  update?: Maybe<GroupUpdateWithoutThreadsDataInput>;
-  upsert?: Maybe<GroupUpsertWithoutThreadsInput>;
-  delete?: Maybe<Boolean>;
-  disconnect?: Maybe<Boolean>;
-  connect?: Maybe<GroupWhereUniqueInput>;
-}
-
-export interface PostUpdateManyWithWhereNestedInput {
-  where: PostScalarWhereInput;
-  data: PostUpdateManyDataInput;
-}
-
-export interface PostUpdateInput {
-  content?: Maybe<String>;
-  moderation?: Maybe<ModerationUpdateOneInput>;
-  thread?: Maybe<ThreadUpdateOneWithoutPostsInput>;
-}
-
-export interface PostUpdateManyDataInput {
-  content?: Maybe<String>;
-}
-
-export interface GroupCreateInput {
-  id?: Maybe<ID_Input>;
-  description: String;
-  name: String;
-  threads?: Maybe<ThreadCreateManyWithoutGroupInput>;
-}
-
-export interface ThreadUpsertWithWhereUniqueWithoutGroupInput {
-  where: ThreadWhereUniqueInput;
-  update: ThreadUpdateWithoutGroupDataInput;
-  create: ThreadCreateWithoutGroupInput;
+export interface PostCreateManyWithoutThreadInput {
+  create?: Maybe<PostCreateWithoutThreadInput[] | PostCreateWithoutThreadInput>;
+  connect?: Maybe<PostWhereUniqueInput[] | PostWhereUniqueInput>;
 }
 
 export interface GroupSubscriptionWhereInput {
@@ -771,7 +479,123 @@ export interface GroupSubscriptionWhereInput {
   NOT?: Maybe<GroupSubscriptionWhereInput[] | GroupSubscriptionWhereInput>;
 }
 
-export interface ThreadScalarWhereInput {
+export interface PostCreateWithoutThreadInput {
+  id?: Maybe<ID_Input>;
+  content: String;
+  moderation?: Maybe<ModerationCreateOneInput>;
+}
+
+export interface ThreadUpdateInput {
+  group?: Maybe<GroupUpdateOneWithoutThreadsInput>;
+  moderation?: Maybe<ModerationUpdateOneInput>;
+  posts?: Maybe<PostUpdateManyWithoutThreadInput>;
+  title?: Maybe<String>;
+}
+
+export interface GroupUpdateInput {
+  description?: Maybe<String>;
+  moderation?: Maybe<ModerationUpdateOneInput>;
+  name?: Maybe<String>;
+  threads?: Maybe<ThreadUpdateManyWithoutGroupInput>;
+}
+
+export interface PostUpdateManyMutationInput {
+  content?: Maybe<String>;
+}
+
+export interface ModerationUpdateOneInput {
+  create?: Maybe<ModerationCreateInput>;
+  update?: Maybe<ModerationUpdateDataInput>;
+  upsert?: Maybe<ModerationUpsertNestedInput>;
+  delete?: Maybe<Boolean>;
+  disconnect?: Maybe<Boolean>;
+  connect?: Maybe<ModerationWhereUniqueInput>;
+}
+
+export interface ThreadUpsertWithoutPostsInput {
+  update: ThreadUpdateWithoutPostsDataInput;
+  create: ThreadCreateWithoutPostsInput;
+}
+
+export interface ModerationUpdateDataInput {
+  status?: Maybe<ModerationStatus>;
+}
+
+export interface GroupUpdateWithoutThreadsDataInput {
+  description?: Maybe<String>;
+  moderation?: Maybe<ModerationUpdateOneInput>;
+  name?: Maybe<String>;
+}
+
+export interface ModerationUpsertNestedInput {
+  update: ModerationUpdateDataInput;
+  create: ModerationCreateInput;
+}
+
+export type PostWhereUniqueInput = AtLeastOne<{
+  id: Maybe<ID_Input>;
+}>;
+
+export interface ThreadCreateOneWithoutPostsInput {
+  create?: Maybe<ThreadCreateWithoutPostsInput>;
+  connect?: Maybe<ThreadWhereUniqueInput>;
+}
+
+export interface ThreadUpdateOneWithoutPostsInput {
+  create?: Maybe<ThreadCreateWithoutPostsInput>;
+  update?: Maybe<ThreadUpdateWithoutPostsDataInput>;
+  upsert?: Maybe<ThreadUpsertWithoutPostsInput>;
+  delete?: Maybe<Boolean>;
+  disconnect?: Maybe<Boolean>;
+  connect?: Maybe<ThreadWhereUniqueInput>;
+}
+
+export interface ThreadUpdateWithWhereUniqueWithoutGroupInput {
+  where: ThreadWhereUniqueInput;
+  data: ThreadUpdateWithoutGroupDataInput;
+}
+
+export type ThreadWhereUniqueInput = AtLeastOne<{
+  id: Maybe<ID_Input>;
+}>;
+
+export interface ThreadUpdateWithoutGroupDataInput {
+  moderation?: Maybe<ModerationUpdateOneInput>;
+  posts?: Maybe<PostUpdateManyWithoutThreadInput>;
+  title?: Maybe<String>;
+}
+
+export interface GroupCreateOneWithoutThreadsInput {
+  create?: Maybe<GroupCreateWithoutThreadsInput>;
+  connect?: Maybe<GroupWhereUniqueInput>;
+}
+
+export interface PostUpdateManyWithoutThreadInput {
+  create?: Maybe<PostCreateWithoutThreadInput[] | PostCreateWithoutThreadInput>;
+  delete?: Maybe<PostWhereUniqueInput[] | PostWhereUniqueInput>;
+  connect?: Maybe<PostWhereUniqueInput[] | PostWhereUniqueInput>;
+  set?: Maybe<PostWhereUniqueInput[] | PostWhereUniqueInput>;
+  disconnect?: Maybe<PostWhereUniqueInput[] | PostWhereUniqueInput>;
+  update?: Maybe<
+    | PostUpdateWithWhereUniqueWithoutThreadInput[]
+    | PostUpdateWithWhereUniqueWithoutThreadInput
+  >;
+  upsert?: Maybe<
+    | PostUpsertWithWhereUniqueWithoutThreadInput[]
+    | PostUpsertWithWhereUniqueWithoutThreadInput
+  >;
+  deleteMany?: Maybe<PostScalarWhereInput[] | PostScalarWhereInput>;
+  updateMany?: Maybe<
+    PostUpdateManyWithWhereNestedInput[] | PostUpdateManyWithWhereNestedInput
+  >;
+}
+
+export interface ModerationCreateOneInput {
+  create?: Maybe<ModerationCreateInput>;
+  connect?: Maybe<ModerationWhereUniqueInput>;
+}
+
+export interface ModerationWhereInput {
   id?: Maybe<ID_Input>;
   id_not?: Maybe<ID_Input>;
   id_in?: Maybe<ID_Input[] | ID_Input>;
@@ -802,60 +626,31 @@ export interface ThreadScalarWhereInput {
   updatedAt_lte?: Maybe<DateTimeInput>;
   updatedAt_gt?: Maybe<DateTimeInput>;
   updatedAt_gte?: Maybe<DateTimeInput>;
-  title?: Maybe<String>;
-  title_not?: Maybe<String>;
-  title_in?: Maybe<String[] | String>;
-  title_not_in?: Maybe<String[] | String>;
-  title_lt?: Maybe<String>;
-  title_lte?: Maybe<String>;
-  title_gt?: Maybe<String>;
-  title_gte?: Maybe<String>;
-  title_contains?: Maybe<String>;
-  title_not_contains?: Maybe<String>;
-  title_starts_with?: Maybe<String>;
-  title_not_starts_with?: Maybe<String>;
-  title_ends_with?: Maybe<String>;
-  title_not_ends_with?: Maybe<String>;
-  AND?: Maybe<ThreadScalarWhereInput[] | ThreadScalarWhereInput>;
-  OR?: Maybe<ThreadScalarWhereInput[] | ThreadScalarWhereInput>;
-  NOT?: Maybe<ThreadScalarWhereInput[] | ThreadScalarWhereInput>;
-}
-
-export interface GroupUpdateWithoutThreadsDataInput {
-  description?: Maybe<String>;
-  name?: Maybe<String>;
-}
-
-export interface ModerationUpdateManyMutationInput {
   status?: Maybe<ModerationStatus>;
+  status_not?: Maybe<ModerationStatus>;
+  status_in?: Maybe<ModerationStatus[] | ModerationStatus>;
+  status_not_in?: Maybe<ModerationStatus[] | ModerationStatus>;
+  AND?: Maybe<ModerationWhereInput[] | ModerationWhereInput>;
+  OR?: Maybe<ModerationWhereInput[] | ModerationWhereInput>;
+  NOT?: Maybe<ModerationWhereInput[] | ModerationWhereInput>;
 }
 
-export interface GroupUpdateManyMutationInput {
-  description?: Maybe<String>;
-  name?: Maybe<String>;
+export interface ModerationSubscriptionWhereInput {
+  mutation_in?: Maybe<MutationType[] | MutationType>;
+  updatedFields_contains?: Maybe<String>;
+  updatedFields_contains_every?: Maybe<String[] | String>;
+  updatedFields_contains_some?: Maybe<String[] | String>;
+  node?: Maybe<ModerationWhereInput>;
+  AND?: Maybe<
+    ModerationSubscriptionWhereInput[] | ModerationSubscriptionWhereInput
+  >;
+  OR?: Maybe<
+    ModerationSubscriptionWhereInput[] | ModerationSubscriptionWhereInput
+  >;
+  NOT?: Maybe<
+    ModerationSubscriptionWhereInput[] | ModerationSubscriptionWhereInput
+  >;
 }
-
-export interface ThreadUpdateManyDataInput {
-  title?: Maybe<String>;
-}
-
-export interface ThreadUpdateManyWithWhereNestedInput {
-  where: ThreadScalarWhereInput;
-  data: ThreadUpdateManyDataInput;
-}
-
-export interface ThreadUpdateOneWithoutPostsInput {
-  create?: Maybe<ThreadCreateWithoutPostsInput>;
-  update?: Maybe<ThreadUpdateWithoutPostsDataInput>;
-  upsert?: Maybe<ThreadUpsertWithoutPostsInput>;
-  delete?: Maybe<Boolean>;
-  disconnect?: Maybe<Boolean>;
-  connect?: Maybe<ThreadWhereUniqueInput>;
-}
-
-export type ModerationWhereUniqueInput = AtLeastOne<{
-  id: Maybe<ID_Input>;
-}>;
 
 export interface ThreadWhereInput {
   id?: Maybe<ID_Input>;
@@ -912,9 +707,219 @@ export interface ThreadWhereInput {
   NOT?: Maybe<ThreadWhereInput[] | ThreadWhereInput>;
 }
 
-export interface GroupCreateOneWithoutThreadsInput {
+export interface ThreadCreateInput {
+  id?: Maybe<ID_Input>;
+  group?: Maybe<GroupCreateOneWithoutThreadsInput>;
+  moderation?: Maybe<ModerationCreateOneInput>;
+  posts?: Maybe<PostCreateManyWithoutThreadInput>;
+  title: String;
+}
+
+export interface PostCreateInput {
+  id?: Maybe<ID_Input>;
+  content: String;
+  moderation?: Maybe<ModerationCreateOneInput>;
+  thread?: Maybe<ThreadCreateOneWithoutPostsInput>;
+}
+
+export interface GroupUpsertWithoutThreadsInput {
+  update: GroupUpdateWithoutThreadsDataInput;
+  create: GroupCreateWithoutThreadsInput;
+}
+
+export interface PostScalarWhereInput {
+  id?: Maybe<ID_Input>;
+  id_not?: Maybe<ID_Input>;
+  id_in?: Maybe<ID_Input[] | ID_Input>;
+  id_not_in?: Maybe<ID_Input[] | ID_Input>;
+  id_lt?: Maybe<ID_Input>;
+  id_lte?: Maybe<ID_Input>;
+  id_gt?: Maybe<ID_Input>;
+  id_gte?: Maybe<ID_Input>;
+  id_contains?: Maybe<ID_Input>;
+  id_not_contains?: Maybe<ID_Input>;
+  id_starts_with?: Maybe<ID_Input>;
+  id_not_starts_with?: Maybe<ID_Input>;
+  id_ends_with?: Maybe<ID_Input>;
+  id_not_ends_with?: Maybe<ID_Input>;
+  createdAt?: Maybe<DateTimeInput>;
+  createdAt_not?: Maybe<DateTimeInput>;
+  createdAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  createdAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  createdAt_lt?: Maybe<DateTimeInput>;
+  createdAt_lte?: Maybe<DateTimeInput>;
+  createdAt_gt?: Maybe<DateTimeInput>;
+  createdAt_gte?: Maybe<DateTimeInput>;
+  updatedAt?: Maybe<DateTimeInput>;
+  updatedAt_not?: Maybe<DateTimeInput>;
+  updatedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  updatedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  updatedAt_lt?: Maybe<DateTimeInput>;
+  updatedAt_lte?: Maybe<DateTimeInput>;
+  updatedAt_gt?: Maybe<DateTimeInput>;
+  updatedAt_gte?: Maybe<DateTimeInput>;
+  content?: Maybe<String>;
+  content_not?: Maybe<String>;
+  content_in?: Maybe<String[] | String>;
+  content_not_in?: Maybe<String[] | String>;
+  content_lt?: Maybe<String>;
+  content_lte?: Maybe<String>;
+  content_gt?: Maybe<String>;
+  content_gte?: Maybe<String>;
+  content_contains?: Maybe<String>;
+  content_not_contains?: Maybe<String>;
+  content_starts_with?: Maybe<String>;
+  content_not_starts_with?: Maybe<String>;
+  content_ends_with?: Maybe<String>;
+  content_not_ends_with?: Maybe<String>;
+  AND?: Maybe<PostScalarWhereInput[] | PostScalarWhereInput>;
+  OR?: Maybe<PostScalarWhereInput[] | PostScalarWhereInput>;
+  NOT?: Maybe<PostScalarWhereInput[] | PostScalarWhereInput>;
+}
+
+export interface ThreadUpdateWithoutPostsDataInput {
+  group?: Maybe<GroupUpdateOneWithoutThreadsInput>;
+  moderation?: Maybe<ModerationUpdateOneInput>;
+  title?: Maybe<String>;
+}
+
+export interface PostUpdateManyWithWhereNestedInput {
+  where: PostScalarWhereInput;
+  data: PostUpdateManyDataInput;
+}
+
+export interface GroupCreateWithoutThreadsInput {
+  id?: Maybe<ID_Input>;
+  description: String;
+  moderation?: Maybe<ModerationCreateOneInput>;
+  name: String;
+}
+
+export interface PostUpdateManyDataInput {
+  content?: Maybe<String>;
+}
+
+export interface GroupCreateInput {
+  id?: Maybe<ID_Input>;
+  description: String;
+  moderation?: Maybe<ModerationCreateOneInput>;
+  name: String;
+  threads?: Maybe<ThreadCreateManyWithoutGroupInput>;
+}
+
+export interface ThreadUpsertWithWhereUniqueWithoutGroupInput {
+  where: ThreadWhereUniqueInput;
+  update: ThreadUpdateWithoutGroupDataInput;
+  create: ThreadCreateWithoutGroupInput;
+}
+
+export interface ThreadUpdateManyMutationInput {
+  title?: Maybe<String>;
+}
+
+export interface ThreadScalarWhereInput {
+  id?: Maybe<ID_Input>;
+  id_not?: Maybe<ID_Input>;
+  id_in?: Maybe<ID_Input[] | ID_Input>;
+  id_not_in?: Maybe<ID_Input[] | ID_Input>;
+  id_lt?: Maybe<ID_Input>;
+  id_lte?: Maybe<ID_Input>;
+  id_gt?: Maybe<ID_Input>;
+  id_gte?: Maybe<ID_Input>;
+  id_contains?: Maybe<ID_Input>;
+  id_not_contains?: Maybe<ID_Input>;
+  id_starts_with?: Maybe<ID_Input>;
+  id_not_starts_with?: Maybe<ID_Input>;
+  id_ends_with?: Maybe<ID_Input>;
+  id_not_ends_with?: Maybe<ID_Input>;
+  createdAt?: Maybe<DateTimeInput>;
+  createdAt_not?: Maybe<DateTimeInput>;
+  createdAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  createdAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  createdAt_lt?: Maybe<DateTimeInput>;
+  createdAt_lte?: Maybe<DateTimeInput>;
+  createdAt_gt?: Maybe<DateTimeInput>;
+  createdAt_gte?: Maybe<DateTimeInput>;
+  updatedAt?: Maybe<DateTimeInput>;
+  updatedAt_not?: Maybe<DateTimeInput>;
+  updatedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  updatedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  updatedAt_lt?: Maybe<DateTimeInput>;
+  updatedAt_lte?: Maybe<DateTimeInput>;
+  updatedAt_gt?: Maybe<DateTimeInput>;
+  updatedAt_gte?: Maybe<DateTimeInput>;
+  title?: Maybe<String>;
+  title_not?: Maybe<String>;
+  title_in?: Maybe<String[] | String>;
+  title_not_in?: Maybe<String[] | String>;
+  title_lt?: Maybe<String>;
+  title_lte?: Maybe<String>;
+  title_gt?: Maybe<String>;
+  title_gte?: Maybe<String>;
+  title_contains?: Maybe<String>;
+  title_not_contains?: Maybe<String>;
+  title_starts_with?: Maybe<String>;
+  title_not_starts_with?: Maybe<String>;
+  title_ends_with?: Maybe<String>;
+  title_not_ends_with?: Maybe<String>;
+  AND?: Maybe<ThreadScalarWhereInput[] | ThreadScalarWhereInput>;
+  OR?: Maybe<ThreadScalarWhereInput[] | ThreadScalarWhereInput>;
+  NOT?: Maybe<ThreadScalarWhereInput[] | ThreadScalarWhereInput>;
+}
+
+export interface GroupUpdateOneWithoutThreadsInput {
   create?: Maybe<GroupCreateWithoutThreadsInput>;
+  update?: Maybe<GroupUpdateWithoutThreadsDataInput>;
+  upsert?: Maybe<GroupUpsertWithoutThreadsInput>;
+  delete?: Maybe<Boolean>;
+  disconnect?: Maybe<Boolean>;
   connect?: Maybe<GroupWhereUniqueInput>;
+}
+
+export interface ModerationUpdateManyMutationInput {
+  status?: Maybe<ModerationStatus>;
+}
+
+export interface GroupUpdateManyMutationInput {
+  description?: Maybe<String>;
+  name?: Maybe<String>;
+}
+
+export interface ThreadUpdateManyDataInput {
+  title?: Maybe<String>;
+}
+
+export interface ThreadUpdateManyWithWhereNestedInput {
+  where: ThreadScalarWhereInput;
+  data: ThreadUpdateManyDataInput;
+}
+
+export interface PostUpdateInput {
+  content?: Maybe<String>;
+  moderation?: Maybe<ModerationUpdateOneInput>;
+  thread?: Maybe<ThreadUpdateOneWithoutPostsInput>;
+}
+
+export type ModerationWhereUniqueInput = AtLeastOne<{
+  id: Maybe<ID_Input>;
+}>;
+
+export interface ThreadSubscriptionWhereInput {
+  mutation_in?: Maybe<MutationType[] | MutationType>;
+  updatedFields_contains?: Maybe<String>;
+  updatedFields_contains_every?: Maybe<String[] | String>;
+  updatedFields_contains_some?: Maybe<String[] | String>;
+  node?: Maybe<ThreadWhereInput>;
+  AND?: Maybe<ThreadSubscriptionWhereInput[] | ThreadSubscriptionWhereInput>;
+  OR?: Maybe<ThreadSubscriptionWhereInput[] | ThreadSubscriptionWhereInput>;
+  NOT?: Maybe<ThreadSubscriptionWhereInput[] | ThreadSubscriptionWhereInput>;
+}
+
+export interface ThreadCreateWithoutPostsInput {
+  id?: Maybe<ID_Input>;
+  group?: Maybe<GroupCreateOneWithoutThreadsInput>;
+  moderation?: Maybe<ModerationCreateOneInput>;
+  title: String;
 }
 
 export interface NodeNode {
@@ -944,104 +949,6 @@ export interface ThreadPreviousValuesSubscription
   createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
   updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
   title: () => Promise<AsyncIterator<String>>;
-}
-
-export interface AggregateGroup {
-  count: Int;
-}
-
-export interface AggregateGroupPromise
-  extends Promise<AggregateGroup>,
-    Fragmentable {
-  count: () => Promise<Int>;
-}
-
-export interface AggregateGroupSubscription
-  extends Promise<AsyncIterator<AggregateGroup>>,
-    Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
-}
-
-export interface Thread {
-  id: ID_Output;
-  createdAt: DateTimeOutput;
-  updatedAt: DateTimeOutput;
-  title: String;
-}
-
-export interface ThreadPromise extends Promise<Thread>, Fragmentable {
-  id: () => Promise<ID_Output>;
-  createdAt: () => Promise<DateTimeOutput>;
-  updatedAt: () => Promise<DateTimeOutput>;
-  group: <T = GroupPromise>() => T;
-  moderation: <T = ModerationPromise>() => T;
-  posts: <T = FragmentableArray<Post>>(args?: {
-    where?: PostWhereInput;
-    orderBy?: PostOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-  title: () => Promise<String>;
-}
-
-export interface ThreadSubscription
-  extends Promise<AsyncIterator<Thread>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  group: <T = GroupSubscription>() => T;
-  moderation: <T = ModerationSubscription>() => T;
-  posts: <T = Promise<AsyncIterator<PostSubscription>>>(args?: {
-    where?: PostWhereInput;
-    orderBy?: PostOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-  title: () => Promise<AsyncIterator<String>>;
-}
-
-export interface ThreadNullablePromise
-  extends Promise<Thread | null>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  createdAt: () => Promise<DateTimeOutput>;
-  updatedAt: () => Promise<DateTimeOutput>;
-  group: <T = GroupPromise>() => T;
-  moderation: <T = ModerationPromise>() => T;
-  posts: <T = FragmentableArray<Post>>(args?: {
-    where?: PostWhereInput;
-    orderBy?: PostOrderByInput;
-    skip?: Int;
-    after?: String;
-    before?: String;
-    first?: Int;
-    last?: Int;
-  }) => T;
-  title: () => Promise<String>;
-}
-
-export interface GroupEdge {
-  node: Group;
-  cursor: String;
-}
-
-export interface GroupEdgePromise extends Promise<GroupEdge>, Fragmentable {
-  node: <T = GroupPromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface GroupEdgeSubscription
-  extends Promise<AsyncIterator<GroupEdge>>,
-    Fragmentable {
-  node: <T = GroupSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
 }
 
 export interface Moderation {
@@ -1114,66 +1021,120 @@ export interface PostNullablePromise
   thread: <T = ThreadPromise>() => T;
 }
 
-export interface PostSubscriptionPayload {
-  mutation: MutationType;
-  node: Post;
-  updatedFields: String[];
-  previousValues: PostPreviousValues;
-}
-
-export interface PostSubscriptionPayloadPromise
-  extends Promise<PostSubscriptionPayload>,
-    Fragmentable {
-  mutation: () => Promise<MutationType>;
-  node: <T = PostPromise>() => T;
-  updatedFields: () => Promise<String[]>;
-  previousValues: <T = PostPreviousValuesPromise>() => T;
-}
-
-export interface PostSubscriptionPayloadSubscription
-  extends Promise<AsyncIterator<PostSubscriptionPayload>>,
-    Fragmentable {
-  mutation: () => Promise<AsyncIterator<MutationType>>;
-  node: <T = PostSubscription>() => T;
-  updatedFields: () => Promise<AsyncIterator<String[]>>;
-  previousValues: <T = PostPreviousValuesSubscription>() => T;
-}
-
-export interface AggregateThread {
+export interface AggregateGroup {
   count: Int;
 }
 
-export interface AggregateThreadPromise
-  extends Promise<AggregateThread>,
+export interface AggregateGroupPromise
+  extends Promise<AggregateGroup>,
     Fragmentable {
   count: () => Promise<Int>;
 }
 
-export interface AggregateThreadSubscription
-  extends Promise<AsyncIterator<AggregateThread>>,
+export interface AggregateGroupSubscription
+  extends Promise<AsyncIterator<AggregateGroup>>,
     Fragmentable {
   count: () => Promise<AsyncIterator<Int>>;
 }
 
-export interface ThreadConnection {
-  pageInfo: PageInfo;
-  edges: ThreadEdge[];
+export interface GroupEdge {
+  node: Group;
+  cursor: String;
 }
 
-export interface ThreadConnectionPromise
-  extends Promise<ThreadConnection>,
-    Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<ThreadEdge>>() => T;
-  aggregate: <T = AggregateThreadPromise>() => T;
+export interface GroupEdgePromise extends Promise<GroupEdge>, Fragmentable {
+  node: <T = GroupPromise>() => T;
+  cursor: () => Promise<String>;
 }
 
-export interface ThreadConnectionSubscription
-  extends Promise<AsyncIterator<ThreadConnection>>,
+export interface GroupEdgeSubscription
+  extends Promise<AsyncIterator<GroupEdge>>,
     Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<ThreadEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateThreadSubscription>() => T;
+  node: <T = GroupSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface BatchPayload {
+  count: Long;
+}
+
+export interface BatchPayloadPromise
+  extends Promise<BatchPayload>,
+    Fragmentable {
+  count: () => Promise<Long>;
+}
+
+export interface BatchPayloadSubscription
+  extends Promise<AsyncIterator<BatchPayload>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Long>>;
+}
+
+export interface ThreadSubscriptionPayload {
+  mutation: MutationType;
+  node: Thread;
+  updatedFields: String[];
+  previousValues: ThreadPreviousValues;
+}
+
+export interface ThreadSubscriptionPayloadPromise
+  extends Promise<ThreadSubscriptionPayload>,
+    Fragmentable {
+  mutation: () => Promise<MutationType>;
+  node: <T = ThreadPromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = ThreadPreviousValuesPromise>() => T;
+}
+
+export interface ThreadSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<ThreadSubscriptionPayload>>,
+    Fragmentable {
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = ThreadSubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = ThreadPreviousValuesSubscription>() => T;
+}
+
+export interface PostPreviousValues {
+  id: ID_Output;
+  createdAt: DateTimeOutput;
+  updatedAt: DateTimeOutput;
+  content: String;
+}
+
+export interface PostPreviousValuesPromise
+  extends Promise<PostPreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  content: () => Promise<String>;
+}
+
+export interface PostPreviousValuesSubscription
+  extends Promise<AsyncIterator<PostPreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  content: () => Promise<AsyncIterator<String>>;
+}
+
+export interface ThreadEdge {
+  node: Thread;
+  cursor: String;
+}
+
+export interface ThreadEdgePromise extends Promise<ThreadEdge>, Fragmentable {
+  node: <T = ThreadPromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface ThreadEdgeSubscription
+  extends Promise<AsyncIterator<ThreadEdge>>,
+    Fragmentable {
+  node: <T = ThreadSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
 }
 
 export interface PageInfo {
@@ -1199,21 +1160,62 @@ export interface PageInfoSubscription
   endCursor: () => Promise<AsyncIterator<String>>;
 }
 
-export interface PostEdge {
-  node: Post;
-  cursor: String;
+export interface AggregatePost {
+  count: Int;
 }
 
-export interface PostEdgePromise extends Promise<PostEdge>, Fragmentable {
-  node: <T = PostPromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface PostEdgeSubscription
-  extends Promise<AsyncIterator<PostEdge>>,
+export interface AggregatePostPromise
+  extends Promise<AggregatePost>,
     Fragmentable {
-  node: <T = PostSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
+  count: () => Promise<Int>;
+}
+
+export interface AggregatePostSubscription
+  extends Promise<AsyncIterator<AggregatePost>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface GroupConnection {
+  pageInfo: PageInfo;
+  edges: GroupEdge[];
+}
+
+export interface GroupConnectionPromise
+  extends Promise<GroupConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<GroupEdge>>() => T;
+  aggregate: <T = AggregateGroupPromise>() => T;
+}
+
+export interface GroupConnectionSubscription
+  extends Promise<AsyncIterator<GroupConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<GroupEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateGroupSubscription>() => T;
+}
+
+export interface PostConnection {
+  pageInfo: PageInfo;
+  edges: PostEdge[];
+}
+
+export interface PostConnectionPromise
+  extends Promise<PostConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<PostEdge>>() => T;
+  aggregate: <T = AggregatePostPromise>() => T;
+}
+
+export interface PostConnectionSubscription
+  extends Promise<AsyncIterator<PostConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<PostEdgeSubscription>>>() => T;
+  aggregate: <T = AggregatePostSubscription>() => T;
 }
 
 export interface Group {
@@ -1229,6 +1231,7 @@ export interface GroupPromise extends Promise<Group>, Fragmentable {
   createdAt: () => Promise<DateTimeOutput>;
   updatedAt: () => Promise<DateTimeOutput>;
   description: () => Promise<String>;
+  moderation: <T = ModerationPromise>() => T;
   name: () => Promise<String>;
   threads: <T = FragmentableArray<Thread>>(args?: {
     where?: ThreadWhereInput;
@@ -1248,6 +1251,7 @@ export interface GroupSubscription
   createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
   updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
   description: () => Promise<AsyncIterator<String>>;
+  moderation: <T = ModerationSubscription>() => T;
   name: () => Promise<AsyncIterator<String>>;
   threads: <T = Promise<AsyncIterator<ThreadSubscription>>>(args?: {
     where?: ThreadWhereInput;
@@ -1267,6 +1271,7 @@ export interface GroupNullablePromise
   createdAt: () => Promise<DateTimeOutput>;
   updatedAt: () => Promise<DateTimeOutput>;
   description: () => Promise<String>;
+  moderation: <T = ModerationPromise>() => T;
   name: () => Promise<String>;
   threads: <T = FragmentableArray<Thread>>(args?: {
     where?: ThreadWhereInput;
@@ -1279,20 +1284,23 @@ export interface GroupNullablePromise
   }) => T;
 }
 
-export interface AggregateModeration {
-  count: Int;
+export interface ModerationEdge {
+  node: Moderation;
+  cursor: String;
 }
 
-export interface AggregateModerationPromise
-  extends Promise<AggregateModeration>,
+export interface ModerationEdgePromise
+  extends Promise<ModerationEdge>,
     Fragmentable {
-  count: () => Promise<Int>;
+  node: <T = ModerationPromise>() => T;
+  cursor: () => Promise<String>;
 }
 
-export interface AggregateModerationSubscription
-  extends Promise<AsyncIterator<AggregateModeration>>,
+export interface ModerationEdgeSubscription
+  extends Promise<AsyncIterator<ModerationEdge>>,
     Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
+  node: <T = ModerationSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
 }
 
 export interface GroupSubscriptionPayload {
@@ -1320,94 +1328,90 @@ export interface GroupSubscriptionPayloadSubscription
   previousValues: <T = GroupPreviousValuesSubscription>() => T;
 }
 
-export interface ModerationConnection {
-  pageInfo: PageInfo;
-  edges: ModerationEdge[];
+export interface Thread {
+  id: ID_Output;
+  createdAt: DateTimeOutput;
+  updatedAt: DateTimeOutput;
+  title: String;
 }
 
-export interface ModerationConnectionPromise
-  extends Promise<ModerationConnection>,
+export interface ThreadPromise extends Promise<Thread>, Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  group: <T = GroupPromise>() => T;
+  moderation: <T = ModerationPromise>() => T;
+  posts: <T = FragmentableArray<Post>>(args?: {
+    where?: PostWhereInput;
+    orderBy?: PostOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  title: () => Promise<String>;
+}
+
+export interface ThreadSubscription
+  extends Promise<AsyncIterator<Thread>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  group: <T = GroupSubscription>() => T;
+  moderation: <T = ModerationSubscription>() => T;
+  posts: <T = Promise<AsyncIterator<PostSubscription>>>(args?: {
+    where?: PostWhereInput;
+    orderBy?: PostOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  title: () => Promise<AsyncIterator<String>>;
+}
+
+export interface ThreadNullablePromise
+  extends Promise<Thread | null>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  group: <T = GroupPromise>() => T;
+  moderation: <T = ModerationPromise>() => T;
+  posts: <T = FragmentableArray<Post>>(args?: {
+    where?: PostWhereInput;
+    orderBy?: PostOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  title: () => Promise<String>;
+}
+
+export interface ThreadConnection {
+  pageInfo: PageInfo;
+  edges: ThreadEdge[];
+}
+
+export interface ThreadConnectionPromise
+  extends Promise<ThreadConnection>,
     Fragmentable {
   pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<ModerationEdge>>() => T;
-  aggregate: <T = AggregateModerationPromise>() => T;
+  edges: <T = FragmentableArray<ThreadEdge>>() => T;
+  aggregate: <T = AggregateThreadPromise>() => T;
 }
 
-export interface ModerationConnectionSubscription
-  extends Promise<AsyncIterator<ModerationConnection>>,
+export interface ThreadConnectionSubscription
+  extends Promise<AsyncIterator<ThreadConnection>>,
     Fragmentable {
   pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<ModerationEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateModerationSubscription>() => T;
-}
-
-export interface GroupPreviousValues {
-  id: ID_Output;
-  createdAt: DateTimeOutput;
-  updatedAt: DateTimeOutput;
-  description: String;
-  name: String;
-}
-
-export interface GroupPreviousValuesPromise
-  extends Promise<GroupPreviousValues>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  createdAt: () => Promise<DateTimeOutput>;
-  updatedAt: () => Promise<DateTimeOutput>;
-  description: () => Promise<String>;
-  name: () => Promise<String>;
-}
-
-export interface GroupPreviousValuesSubscription
-  extends Promise<AsyncIterator<GroupPreviousValues>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  description: () => Promise<AsyncIterator<String>>;
-  name: () => Promise<AsyncIterator<String>>;
-}
-
-export interface BatchPayload {
-  count: Long;
-}
-
-export interface BatchPayloadPromise
-  extends Promise<BatchPayload>,
-    Fragmentable {
-  count: () => Promise<Long>;
-}
-
-export interface BatchPayloadSubscription
-  extends Promise<AsyncIterator<BatchPayload>>,
-    Fragmentable {
-  count: () => Promise<AsyncIterator<Long>>;
-}
-
-export interface PostPreviousValues {
-  id: ID_Output;
-  createdAt: DateTimeOutput;
-  updatedAt: DateTimeOutput;
-  content: String;
-}
-
-export interface PostPreviousValuesPromise
-  extends Promise<PostPreviousValues>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  createdAt: () => Promise<DateTimeOutput>;
-  updatedAt: () => Promise<DateTimeOutput>;
-  content: () => Promise<String>;
-}
-
-export interface PostPreviousValuesSubscription
-  extends Promise<AsyncIterator<PostPreviousValues>>,
-    Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  content: () => Promise<AsyncIterator<String>>;
+  edges: <T = Promise<AsyncIterator<ThreadEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateThreadSubscription>() => T;
 }
 
 export interface ModerationPreviousValues {
@@ -1460,129 +1464,133 @@ export interface ModerationSubscriptionPayloadSubscription
   previousValues: <T = ModerationPreviousValuesSubscription>() => T;
 }
 
-export interface GroupConnection {
-  pageInfo: PageInfo;
-  edges: GroupEdge[];
-}
-
-export interface GroupConnectionPromise
-  extends Promise<GroupConnection>,
-    Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<GroupEdge>>() => T;
-  aggregate: <T = AggregateGroupPromise>() => T;
-}
-
-export interface GroupConnectionSubscription
-  extends Promise<AsyncIterator<GroupConnection>>,
-    Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<GroupEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateGroupSubscription>() => T;
-}
-
-export interface ThreadEdge {
-  node: Thread;
-  cursor: String;
-}
-
-export interface ThreadEdgePromise extends Promise<ThreadEdge>, Fragmentable {
-  node: <T = ThreadPromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface ThreadEdgeSubscription
-  extends Promise<AsyncIterator<ThreadEdge>>,
-    Fragmentable {
-  node: <T = ThreadSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
-}
-
-export interface ThreadSubscriptionPayload {
+export interface PostSubscriptionPayload {
   mutation: MutationType;
-  node: Thread;
+  node: Post;
   updatedFields: String[];
-  previousValues: ThreadPreviousValues;
+  previousValues: PostPreviousValues;
 }
 
-export interface ThreadSubscriptionPayloadPromise
-  extends Promise<ThreadSubscriptionPayload>,
+export interface PostSubscriptionPayloadPromise
+  extends Promise<PostSubscriptionPayload>,
     Fragmentable {
   mutation: () => Promise<MutationType>;
-  node: <T = ThreadPromise>() => T;
+  node: <T = PostPromise>() => T;
   updatedFields: () => Promise<String[]>;
-  previousValues: <T = ThreadPreviousValuesPromise>() => T;
+  previousValues: <T = PostPreviousValuesPromise>() => T;
 }
 
-export interface ThreadSubscriptionPayloadSubscription
-  extends Promise<AsyncIterator<ThreadSubscriptionPayload>>,
+export interface PostSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<PostSubscriptionPayload>>,
     Fragmentable {
   mutation: () => Promise<AsyncIterator<MutationType>>;
-  node: <T = ThreadSubscription>() => T;
+  node: <T = PostSubscription>() => T;
   updatedFields: () => Promise<AsyncIterator<String[]>>;
-  previousValues: <T = ThreadPreviousValuesSubscription>() => T;
+  previousValues: <T = PostPreviousValuesSubscription>() => T;
 }
 
-export interface ModerationEdge {
-  node: Moderation;
+export interface GroupPreviousValues {
+  id: ID_Output;
+  createdAt: DateTimeOutput;
+  updatedAt: DateTimeOutput;
+  description: String;
+  name: String;
+}
+
+export interface GroupPreviousValuesPromise
+  extends Promise<GroupPreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  description: () => Promise<String>;
+  name: () => Promise<String>;
+}
+
+export interface GroupPreviousValuesSubscription
+  extends Promise<AsyncIterator<GroupPreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  description: () => Promise<AsyncIterator<String>>;
+  name: () => Promise<AsyncIterator<String>>;
+}
+
+export interface PostEdge {
+  node: Post;
   cursor: String;
 }
 
-export interface ModerationEdgePromise
-  extends Promise<ModerationEdge>,
-    Fragmentable {
-  node: <T = ModerationPromise>() => T;
+export interface PostEdgePromise extends Promise<PostEdge>, Fragmentable {
+  node: <T = PostPromise>() => T;
   cursor: () => Promise<String>;
 }
 
-export interface ModerationEdgeSubscription
-  extends Promise<AsyncIterator<ModerationEdge>>,
+export interface PostEdgeSubscription
+  extends Promise<AsyncIterator<PostEdge>>,
     Fragmentable {
-  node: <T = ModerationSubscription>() => T;
+  node: <T = PostSubscription>() => T;
   cursor: () => Promise<AsyncIterator<String>>;
 }
 
-export interface PostConnection {
-  pageInfo: PageInfo;
-  edges: PostEdge[];
-}
-
-export interface PostConnectionPromise
-  extends Promise<PostConnection>,
-    Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<PostEdge>>() => T;
-  aggregate: <T = AggregatePostPromise>() => T;
-}
-
-export interface PostConnectionSubscription
-  extends Promise<AsyncIterator<PostConnection>>,
-    Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<PostEdgeSubscription>>>() => T;
-  aggregate: <T = AggregatePostSubscription>() => T;
-}
-
-export interface AggregatePost {
+export interface AggregateThread {
   count: Int;
 }
 
-export interface AggregatePostPromise
-  extends Promise<AggregatePost>,
+export interface AggregateThreadPromise
+  extends Promise<AggregateThread>,
     Fragmentable {
   count: () => Promise<Int>;
 }
 
-export interface AggregatePostSubscription
-  extends Promise<AsyncIterator<AggregatePost>>,
+export interface AggregateThreadSubscription
+  extends Promise<AsyncIterator<AggregateThread>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface ModerationConnection {
+  pageInfo: PageInfo;
+  edges: ModerationEdge[];
+}
+
+export interface ModerationConnectionPromise
+  extends Promise<ModerationConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<ModerationEdge>>() => T;
+  aggregate: <T = AggregateModerationPromise>() => T;
+}
+
+export interface ModerationConnectionSubscription
+  extends Promise<AsyncIterator<ModerationConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<ModerationEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateModerationSubscription>() => T;
+}
+
+export interface AggregateModeration {
+  count: Int;
+}
+
+export interface AggregateModerationPromise
+  extends Promise<AggregateModeration>,
+    Fragmentable {
+  count: () => Promise<Int>;
+}
+
+export interface AggregateModerationSubscription
+  extends Promise<AsyncIterator<AggregateModeration>>,
     Fragmentable {
   count: () => Promise<AsyncIterator<Int>>;
 }
 
 /*
-The `Boolean` scalar type represents `true` or `false`.
+The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. 
 */
-export type Boolean = boolean;
+export type Int = number;
 
 export type Long = string;
 
@@ -1603,9 +1611,9 @@ DateTime scalar output type, which is always a string
 export type DateTimeOutput = string;
 
 /*
-The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. 
+The `Boolean` scalar type represents `true` or `false`.
 */
-export type Int = number;
+export type Boolean = boolean;
 
 /*
 The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.

--- a/src/generated/prisma-client/index.js
+++ b/src/generated/prisma-client/index.js
@@ -5,15 +5,23 @@ var typeDefs = require("./prisma-schema").typeDefs;
 
 var models = [
   {
+    name: "ModerationStatus",
+    embedded: false
+  },
+  {
+    name: "Moderation",
+    embedded: false
+  },
+  {
+    name: "Group",
+    embedded: false
+  },
+  {
     name: "Post",
     embedded: false
   },
   {
     name: "Thread",
-    embedded: false
-  },
-  {
-    name: "Group",
     embedded: false
   }
 ];

--- a/src/generated/prisma-client/prisma-schema.js
+++ b/src/generated/prisma-client/prisma-schema.js
@@ -7,6 +7,10 @@ module.exports = {
   count: Int!
 }
 
+type AggregateModeration {
+  count: Int!
+}
+
 type AggregatePost {
   count: Int!
 }
@@ -201,6 +205,145 @@ input GroupWhereUniqueInput {
 
 scalar Long
 
+type Moderation {
+  id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  status: ModerationStatus!
+}
+
+type ModerationConnection {
+  pageInfo: PageInfo!
+  edges: [ModerationEdge]!
+  aggregate: AggregateModeration!
+}
+
+input ModerationCreateInput {
+  id: ID
+  status: ModerationStatus!
+}
+
+input ModerationCreateOneInput {
+  create: ModerationCreateInput
+  connect: ModerationWhereUniqueInput
+}
+
+type ModerationEdge {
+  node: Moderation!
+  cursor: String!
+}
+
+enum ModerationOrderByInput {
+  id_ASC
+  id_DESC
+  createdAt_ASC
+  createdAt_DESC
+  updatedAt_ASC
+  updatedAt_DESC
+  status_ASC
+  status_DESC
+}
+
+type ModerationPreviousValues {
+  id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  status: ModerationStatus!
+}
+
+enum ModerationStatus {
+  TRIGGERED_CONTENT_FILTER
+  APPROVED_BY_MODERATOR
+}
+
+type ModerationSubscriptionPayload {
+  mutation: MutationType!
+  node: Moderation
+  updatedFields: [String!]
+  previousValues: ModerationPreviousValues
+}
+
+input ModerationSubscriptionWhereInput {
+  mutation_in: [MutationType!]
+  updatedFields_contains: String
+  updatedFields_contains_every: [String!]
+  updatedFields_contains_some: [String!]
+  node: ModerationWhereInput
+  AND: [ModerationSubscriptionWhereInput!]
+  OR: [ModerationSubscriptionWhereInput!]
+  NOT: [ModerationSubscriptionWhereInput!]
+}
+
+input ModerationUpdateDataInput {
+  status: ModerationStatus
+}
+
+input ModerationUpdateInput {
+  status: ModerationStatus
+}
+
+input ModerationUpdateManyMutationInput {
+  status: ModerationStatus
+}
+
+input ModerationUpdateOneInput {
+  create: ModerationCreateInput
+  update: ModerationUpdateDataInput
+  upsert: ModerationUpsertNestedInput
+  delete: Boolean
+  disconnect: Boolean
+  connect: ModerationWhereUniqueInput
+}
+
+input ModerationUpsertNestedInput {
+  update: ModerationUpdateDataInput!
+  create: ModerationCreateInput!
+}
+
+input ModerationWhereInput {
+  id: ID
+  id_not: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_gt: ID
+  id_gte: ID
+  id_contains: ID
+  id_not_contains: ID
+  id_starts_with: ID
+  id_not_starts_with: ID
+  id_ends_with: ID
+  id_not_ends_with: ID
+  createdAt: DateTime
+  createdAt_not: DateTime
+  createdAt_in: [DateTime!]
+  createdAt_not_in: [DateTime!]
+  createdAt_lt: DateTime
+  createdAt_lte: DateTime
+  createdAt_gt: DateTime
+  createdAt_gte: DateTime
+  updatedAt: DateTime
+  updatedAt_not: DateTime
+  updatedAt_in: [DateTime!]
+  updatedAt_not_in: [DateTime!]
+  updatedAt_lt: DateTime
+  updatedAt_lte: DateTime
+  updatedAt_gt: DateTime
+  updatedAt_gte: DateTime
+  status: ModerationStatus
+  status_not: ModerationStatus
+  status_in: [ModerationStatus!]
+  status_not_in: [ModerationStatus!]
+  AND: [ModerationWhereInput!]
+  OR: [ModerationWhereInput!]
+  NOT: [ModerationWhereInput!]
+}
+
+input ModerationWhereUniqueInput {
+  id: ID
+}
+
 type Mutation {
   createGroup(data: GroupCreateInput!): Group!
   updateGroup(data: GroupUpdateInput!, where: GroupWhereUniqueInput!): Group
@@ -208,6 +351,12 @@ type Mutation {
   upsertGroup(where: GroupWhereUniqueInput!, create: GroupCreateInput!, update: GroupUpdateInput!): Group!
   deleteGroup(where: GroupWhereUniqueInput!): Group
   deleteManyGroups(where: GroupWhereInput): BatchPayload!
+  createModeration(data: ModerationCreateInput!): Moderation!
+  updateModeration(data: ModerationUpdateInput!, where: ModerationWhereUniqueInput!): Moderation
+  updateManyModerations(data: ModerationUpdateManyMutationInput!, where: ModerationWhereInput): BatchPayload!
+  upsertModeration(where: ModerationWhereUniqueInput!, create: ModerationCreateInput!, update: ModerationUpdateInput!): Moderation!
+  deleteModeration(where: ModerationWhereUniqueInput!): Moderation
+  deleteManyModerations(where: ModerationWhereInput): BatchPayload!
   createPost(data: PostCreateInput!): Post!
   updatePost(data: PostUpdateInput!, where: PostWhereUniqueInput!): Post
   updateManyPosts(data: PostUpdateManyMutationInput!, where: PostWhereInput): BatchPayload!
@@ -243,9 +392,8 @@ type Post {
   id: ID!
   createdAt: DateTime!
   updatedAt: DateTime!
-  abusive: Boolean!
   content: String!
-  published: Boolean!
+  moderation: Moderation
   thread: Thread
 }
 
@@ -257,9 +405,8 @@ type PostConnection {
 
 input PostCreateInput {
   id: ID
-  abusive: Boolean
   content: String!
-  published: Boolean
+  moderation: ModerationCreateOneInput
   thread: ThreadCreateOneWithoutPostsInput
 }
 
@@ -270,9 +417,8 @@ input PostCreateManyWithoutThreadInput {
 
 input PostCreateWithoutThreadInput {
   id: ID
-  abusive: Boolean
   content: String!
-  published: Boolean
+  moderation: ModerationCreateOneInput
 }
 
 type PostEdge {
@@ -287,21 +433,15 @@ enum PostOrderByInput {
   createdAt_DESC
   updatedAt_ASC
   updatedAt_DESC
-  abusive_ASC
-  abusive_DESC
   content_ASC
   content_DESC
-  published_ASC
-  published_DESC
 }
 
 type PostPreviousValues {
   id: ID!
   createdAt: DateTime!
   updatedAt: DateTime!
-  abusive: Boolean!
   content: String!
-  published: Boolean!
 }
 
 input PostScalarWhereInput {
@@ -335,8 +475,6 @@ input PostScalarWhereInput {
   updatedAt_lte: DateTime
   updatedAt_gt: DateTime
   updatedAt_gte: DateTime
-  abusive: Boolean
-  abusive_not: Boolean
   content: String
   content_not: String
   content_in: [String!]
@@ -351,8 +489,6 @@ input PostScalarWhereInput {
   content_not_starts_with: String
   content_ends_with: String
   content_not_ends_with: String
-  published: Boolean
-  published_not: Boolean
   AND: [PostScalarWhereInput!]
   OR: [PostScalarWhereInput!]
   NOT: [PostScalarWhereInput!]
@@ -377,22 +513,17 @@ input PostSubscriptionWhereInput {
 }
 
 input PostUpdateInput {
-  abusive: Boolean
   content: String
-  published: Boolean
+  moderation: ModerationUpdateOneInput
   thread: ThreadUpdateOneWithoutPostsInput
 }
 
 input PostUpdateManyDataInput {
-  abusive: Boolean
   content: String
-  published: Boolean
 }
 
 input PostUpdateManyMutationInput {
-  abusive: Boolean
   content: String
-  published: Boolean
 }
 
 input PostUpdateManyWithoutThreadInput {
@@ -413,9 +544,8 @@ input PostUpdateManyWithWhereNestedInput {
 }
 
 input PostUpdateWithoutThreadDataInput {
-  abusive: Boolean
   content: String
-  published: Boolean
+  moderation: ModerationUpdateOneInput
 }
 
 input PostUpdateWithWhereUniqueWithoutThreadInput {
@@ -460,8 +590,6 @@ input PostWhereInput {
   updatedAt_lte: DateTime
   updatedAt_gt: DateTime
   updatedAt_gte: DateTime
-  abusive: Boolean
-  abusive_not: Boolean
   content: String
   content_not: String
   content_in: [String!]
@@ -476,8 +604,7 @@ input PostWhereInput {
   content_not_starts_with: String
   content_ends_with: String
   content_not_ends_with: String
-  published: Boolean
-  published_not: Boolean
+  moderation: ModerationWhereInput
   thread: ThreadWhereInput
   AND: [PostWhereInput!]
   OR: [PostWhereInput!]
@@ -492,6 +619,9 @@ type Query {
   group(where: GroupWhereUniqueInput!): Group
   groups(where: GroupWhereInput, orderBy: GroupOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Group]!
   groupsConnection(where: GroupWhereInput, orderBy: GroupOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): GroupConnection!
+  moderation(where: ModerationWhereUniqueInput!): Moderation
+  moderations(where: ModerationWhereInput, orderBy: ModerationOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Moderation]!
+  moderationsConnection(where: ModerationWhereInput, orderBy: ModerationOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): ModerationConnection!
   post(where: PostWhereUniqueInput!): Post
   posts(where: PostWhereInput, orderBy: PostOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Post]!
   postsConnection(where: PostWhereInput, orderBy: PostOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): PostConnection!
@@ -503,6 +633,7 @@ type Query {
 
 type Subscription {
   group(where: GroupSubscriptionWhereInput): GroupSubscriptionPayload
+  moderation(where: ModerationSubscriptionWhereInput): ModerationSubscriptionPayload
   post(where: PostSubscriptionWhereInput): PostSubscriptionPayload
   thread(where: ThreadSubscriptionWhereInput): ThreadSubscriptionPayload
 }
@@ -511,10 +642,9 @@ type Thread {
   id: ID!
   createdAt: DateTime!
   updatedAt: DateTime!
-  abusive: Boolean!
   group: Group
+  moderation: Moderation
   posts(where: PostWhereInput, orderBy: PostOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Post!]
-  published: Boolean!
   title: String!
 }
 
@@ -526,10 +656,9 @@ type ThreadConnection {
 
 input ThreadCreateInput {
   id: ID
-  abusive: Boolean
   group: GroupCreateOneWithoutThreadsInput
+  moderation: ModerationCreateOneInput
   posts: PostCreateManyWithoutThreadInput
-  published: Boolean
   title: String!
 }
 
@@ -545,17 +674,15 @@ input ThreadCreateOneWithoutPostsInput {
 
 input ThreadCreateWithoutGroupInput {
   id: ID
-  abusive: Boolean
+  moderation: ModerationCreateOneInput
   posts: PostCreateManyWithoutThreadInput
-  published: Boolean
   title: String!
 }
 
 input ThreadCreateWithoutPostsInput {
   id: ID
-  abusive: Boolean
   group: GroupCreateOneWithoutThreadsInput
-  published: Boolean
+  moderation: ModerationCreateOneInput
   title: String!
 }
 
@@ -571,10 +698,6 @@ enum ThreadOrderByInput {
   createdAt_DESC
   updatedAt_ASC
   updatedAt_DESC
-  abusive_ASC
-  abusive_DESC
-  published_ASC
-  published_DESC
   title_ASC
   title_DESC
 }
@@ -583,8 +706,6 @@ type ThreadPreviousValues {
   id: ID!
   createdAt: DateTime!
   updatedAt: DateTime!
-  abusive: Boolean!
-  published: Boolean!
   title: String!
 }
 
@@ -619,10 +740,6 @@ input ThreadScalarWhereInput {
   updatedAt_lte: DateTime
   updatedAt_gt: DateTime
   updatedAt_gte: DateTime
-  abusive: Boolean
-  abusive_not: Boolean
-  published: Boolean
-  published_not: Boolean
   title: String
   title_not: String
   title_in: [String!]
@@ -661,22 +778,17 @@ input ThreadSubscriptionWhereInput {
 }
 
 input ThreadUpdateInput {
-  abusive: Boolean
   group: GroupUpdateOneWithoutThreadsInput
+  moderation: ModerationUpdateOneInput
   posts: PostUpdateManyWithoutThreadInput
-  published: Boolean
   title: String
 }
 
 input ThreadUpdateManyDataInput {
-  abusive: Boolean
-  published: Boolean
   title: String
 }
 
 input ThreadUpdateManyMutationInput {
-  abusive: Boolean
-  published: Boolean
   title: String
 }
 
@@ -707,16 +819,14 @@ input ThreadUpdateOneWithoutPostsInput {
 }
 
 input ThreadUpdateWithoutGroupDataInput {
-  abusive: Boolean
+  moderation: ModerationUpdateOneInput
   posts: PostUpdateManyWithoutThreadInput
-  published: Boolean
   title: String
 }
 
 input ThreadUpdateWithoutPostsDataInput {
-  abusive: Boolean
   group: GroupUpdateOneWithoutThreadsInput
-  published: Boolean
+  moderation: ModerationUpdateOneInput
   title: String
 }
 
@@ -767,14 +877,11 @@ input ThreadWhereInput {
   updatedAt_lte: DateTime
   updatedAt_gt: DateTime
   updatedAt_gte: DateTime
-  abusive: Boolean
-  abusive_not: Boolean
   group: GroupWhereInput
+  moderation: ModerationWhereInput
   posts_every: PostWhereInput
   posts_some: PostWhereInput
   posts_none: PostWhereInput
-  published: Boolean
-  published_not: Boolean
   title: String
   title_not: String
   title_in: [String!]

--- a/src/generated/prisma-client/prisma-schema.js
+++ b/src/generated/prisma-client/prisma-schema.js
@@ -30,6 +30,7 @@ type Group {
   createdAt: DateTime!
   updatedAt: DateTime!
   description: String!
+  moderation: Moderation
   name: String!
   threads(where: ThreadWhereInput, orderBy: ThreadOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Thread!]
 }
@@ -43,6 +44,7 @@ type GroupConnection {
 input GroupCreateInput {
   id: ID
   description: String!
+  moderation: ModerationCreateOneInput
   name: String!
   threads: ThreadCreateManyWithoutGroupInput
 }
@@ -55,6 +57,7 @@ input GroupCreateOneWithoutThreadsInput {
 input GroupCreateWithoutThreadsInput {
   id: ID
   description: String!
+  moderation: ModerationCreateOneInput
   name: String!
 }
 
@@ -104,6 +107,7 @@ input GroupSubscriptionWhereInput {
 
 input GroupUpdateInput {
   description: String
+  moderation: ModerationUpdateOneInput
   name: String
   threads: ThreadUpdateManyWithoutGroupInput
 }
@@ -124,6 +128,7 @@ input GroupUpdateOneWithoutThreadsInput {
 
 input GroupUpdateWithoutThreadsDataInput {
   description: String
+  moderation: ModerationUpdateOneInput
   name: String
 }
 
@@ -177,6 +182,7 @@ input GroupWhereInput {
   description_not_starts_with: String
   description_ends_with: String
   description_not_ends_with: String
+  moderation: ModerationWhereInput
   name: String
   name_not: String
   name_in: [String!]

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,10 @@ const helmet = require('helmet')
 const { prisma } = require('./generated/prisma-client')
 const { typeDefs } = require('./typeDefs')
 const { resolvers } = require('./resolvers')
+const { dotenv } = require('dotenv')
+if (process.env.NODE_ENV !== 'production') {
+  require('dotenv').config();
+}
 
 const server = new GraphQLServer({
   typeDefs: typeDefs,
@@ -12,10 +16,16 @@ const server = new GraphQLServer({
     return {
       ...request,
       prisma,
+      config: {
+        cleanspeak: {
+          apiKey: process.env.CLEANSPEAK_API_KEY,
+          applicationId: process.env.APPLICATION_ID,
+          baseUrl: process.env.CLEANSPEAK_BASE_URL
+        }
+      },
     }
   },
 })
-
 server.express.use(compression())
 server.express.use(helmet())
 

--- a/src/resolvers/groupsResolvers.js
+++ b/src/resolvers/groupsResolvers.js
@@ -1,6 +1,6 @@
 const groupsResolvers = {
   Group: {
-    threads(root, args, context) {
+    threads(root, args, context, info) {
       return context.prisma
         .group({
           id: root.id
@@ -8,10 +8,9 @@ const groupsResolvers = {
         .threads({
           orderBy: "createdAt_DESC",
           where: {
-            abusive: false,
-            published: true
+            moderation: null
           }
-        })
+        }, info)
     }
   },
   Query: {

--- a/src/resolvers/index.js
+++ b/src/resolvers/index.js
@@ -1,8 +1,9 @@
 const { groupsResolvers } = require('./groupsResolvers');
+const { moderationResolvers } = require('./moderationResolvers');
 const { postsResolvers } = require('./postsResolvers');
 const { threadsResolvers } = require('./threadsResolvers');
 
-const resolvers = [groupsResolvers, postsResolvers, threadsResolvers];
+const resolvers = [groupsResolvers, moderationResolvers, postsResolvers, threadsResolvers];
 
 module.exports = {
   resolvers,

--- a/src/resolvers/moderationResolvers.js
+++ b/src/resolvers/moderationResolvers.js
@@ -1,0 +1,8 @@
+const moderationResolvers = {
+  Moderation: {
+  },
+}
+
+module.exports = {
+  moderationResolvers,
+}

--- a/src/services/moderator.js
+++ b/src/services/moderator.js
@@ -1,0 +1,38 @@
+const filterText = async function(cleanspeakConfig, text) {
+  const data = {
+    "content": {
+      "applicationId": `${cleanspeakConfig.applicationId}`,
+  		"createInstant": Date.now(),
+      "parts": [
+        {
+          "content": `${text}`,
+          "type": "text"
+        }
+      ],
+      "senderId": "f6d3df91-ed4b-48ad-810f-05a367d328c2"
+    }
+  }
+
+  try {
+    const url = cleanspeakConfig.baseUrl + '/content/item/moderate'
+    const response = await fetch(url, {
+      method: 'POST',
+      body: JSON.stringify(data),
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': cleanspeakConfig.apiKey
+      }
+    });
+    const responseBody = await response.json();
+    if (responseBody.contentAction === 'reject') {
+      return true
+    }
+  } catch (error) {
+    console.error('Cleanspeak moderate error:', error);
+  }
+  return false
+}
+
+module.exports = {
+  filterText,
+};

--- a/src/services/moderator.js
+++ b/src/services/moderator.js
@@ -1,3 +1,8 @@
+const moderationStatus = {
+    TRIGGERED_AUTOMATED_FILTER: 0,
+    APPROVED_BY_MODERATOR: 1
+}
+
 const filterText = async function(cleanspeakConfig, text) {
   const data = {
     "content": {
@@ -35,4 +40,5 @@ const filterText = async function(cleanspeakConfig, text) {
 
 module.exports = {
   filterText,
+  moderationStatus,
 };

--- a/src/typeDefs/index.js
+++ b/src/typeDefs/index.js
@@ -1,8 +1,8 @@
 const { query } = require('./query')
 const { mutation } = require('./mutation')
-const { groupType, postType, threadType } = require('./types')
+const { groupType, moderationType, postType, threadType } = require('./types')
 
-const typeDefs = [query, mutation, groupType, postType, threadType]
+const typeDefs = [query, mutation, groupType, moderationType, postType, threadType]
 
 module.exports = {
   typeDefs,

--- a/src/typeDefs/types/groupType.js
+++ b/src/typeDefs/types/groupType.js
@@ -8,6 +8,7 @@ const groupType = gql`
 
     description: String!
     name: String!
+    moderation: Moderation
     threads: [Thread!]!
   }
 `

--- a/src/typeDefs/types/index.js
+++ b/src/typeDefs/types/index.js
@@ -1,9 +1,11 @@
 const { groupType } = require("./groupType")
+const { moderationType } = require("./moderationType")
 const { postType } = require("./postType")
 const { threadType } = require("./threadType")
 
 module.exports = {
-  groupType,  
+  groupType,
+  moderationType,
   postType,
   threadType,
 }

--- a/src/typeDefs/types/moderationType.js
+++ b/src/typeDefs/types/moderationType.js
@@ -1,0 +1,20 @@
+const gql = require('graphql-tag')
+
+const moderationType = gql`
+  enum ModerationStatus {
+    TRIGGERED_CONTENT_FILTER,
+    APPROVED_BY_MODERATOR
+  }
+
+  type Moderation {
+    id: ID!
+    createdAt: DateTime!
+    updatedAt: DateTime!
+
+    status: ModerationStatus!
+  }
+`
+
+module.exports = {
+  moderationType,
+}

--- a/src/typeDefs/types/postType.js
+++ b/src/typeDefs/types/postType.js
@@ -7,9 +7,8 @@ const postType = gql`
     createdAt: DateTime!
     updatedAt: DateTime!
 
-    abusive: Boolean!
     content: String!
-    published: Boolean!
+    moderation: Moderation
     thread: Thread!
   }
 `

--- a/src/typeDefs/types/threadType.js
+++ b/src/typeDefs/types/threadType.js
@@ -6,10 +6,9 @@ const threadType = gql`
     createdAt: DateTime!
     updatedAt: DateTime!
 
-    abusive: Boolean!
     group: Group!
     posts: [Post!]!
-    published: Boolean!
+    moderation: Moderation
     title: String!
   }
 `


### PR DESCRIPTION
This change implements an integration with CleanSpeak for content filtering and moderation.

For both the `createThread` and `createPost` resolvers, we make a call to CleanSpeak's `/content/item/moderate` API and check the result to see if the content is allowed or rejected.  We set `published` and `abusive` variables on the `Thread` or `Post`, which determine if the `Thread` or `Post` may be retrieved from the database.

The filters in CleanSpeak are highly tuneable, so we can run tests and adjust in development before we deploy an initial moderation policy and go live.